### PR TITLE
Check value type of notification hint 'urgency' before dereferencing

### DIFF
--- a/src/themes/coco/coco-theme.c
+++ b/src/themes/coco/coco-theme.c
@@ -602,7 +602,7 @@ set_notification_hints(GtkWindow *nw, GHashTable *hints)
 
 	value = (GValue *)g_hash_table_lookup(hints, "urgency");
 
-	if (value != NULL)
+	if (value != NULL && G_VALUE_HOLDS_UCHAR(value))
 	{
 		windata->urgency = g_value_get_uchar(value);
 

--- a/src/themes/nodoka/nodoka-theme.c
+++ b/src/themes/nodoka/nodoka-theme.c
@@ -1005,7 +1005,7 @@ set_notification_hints(GtkWindow *nw, GHashTable *hints)
 
 	value = (GValue *)g_hash_table_lookup(hints, "urgency");
 
-	if (value != NULL)
+	if (value != NULL && G_VALUE_HOLDS_UCHAR(value))
 	{
 		windata->urgency = g_value_get_uchar(value);
 


### PR DESCRIPTION
mate-notification-daemon currently crashes (in g_value_get_uchar since the type does not match) if nonconforming apps send an urgency hint typed as anything but unsigned char in the nodoka and coco themes. This behaviour should be changed to simply ignoring the hint value.
