### PR TITLE
Fix assertion WNCK_IS_WORKSPACE

### DIFF
--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -1162,6 +1162,11 @@ static gboolean fullscreen_window_exists(GtkWidget* nw)
 
 	wnck_workspace = wnck_screen_get_active_workspace (wnck_screen);
 
+	if (!wnck_workspace)
+	{
+		return FALSE;
+	}
+
 	for (l = wnck_screen_get_windows_stacked (wnck_screen); l != NULL; l = l->next)
 	{
 		WnckWindow *wnck_win = (WnckWindow *) l->data;


### PR DESCRIPTION
Some window manager such as the latest i3-wm may cause `wnck_screen_get_active_workspace` to return NULL which leads to a crash:

```
(mate-notification-daemon:31145): Wnck-CRITICAL **: wnck_window_is_on_workspace: assertion 'WNCK_IS_WORKSPACE (workspace)' failed

Program received signal SIGTRAP, Trace/breakpoint trap.
0x00007ffff445f993 in g_logv () from /usr/lib/libglib-2.0.so.0
(gdb) bt
#0  0x00007ffff445f993 in g_logv () from /usr/lib/libglib-2.0.so.0
#1  0x00007ffff445faf2 in g_log () from /usr/lib/libglib-2.0.so.0
#2  0x00007ffff63dd589 in wnck_window_is_on_workspace () from /usr/lib/libwnck-1.so.22
#3  0x00000000004075a9 in fullscreen_window_exists (nw=0x666b60) at daemon.c:1169
#4  0x000000000040841b in notify_daemon_notify_handler (daemon=0x62c0d0, 
    app_name=0x75d4b0 "mate-notification-properties", id=0, icon=0x6b9680 "dialog-information", 
    summary=0x665440 "Notification Test", body=0x693a00 "Just a test", actions=0x692ba0, hints=0x651c00, 
    timeout=-1, context=0x690490) at daemon.c:1565
#5  0x0000000000404d70 in dbus_glib_marshal_notification_daemon_VOID__STRING_UINT_STRING_STRING_STRING_BOXED_BOXED_INT_POINTER (closure=0x7fffffffde40, return_value=0x0, n_param_values=10, param_values=0x73dc40, 
    invocation_hint=0x0, marshal_data=0x407937 <notify_daemon_notify_handler>)
    at notificationdaemon-dbus-glue.h:102
#6  0x00007ffff79bea1b in ?? () from /usr/lib/libdbus-glib-1.so.2
#7  0x00007ffff778790f in ?? () from /usr/lib/libdbus-1.so.3
#8  0x00007ffff7779574 in dbus_connection_dispatch () from /usr/lib/libdbus-1.so.3
#9  0x00007ffff79bbf95 in ?? () from /usr/lib/libdbus-glib-1.so.2
#10 0x00007ffff4458b84 in g_main_context_dispatch () from /usr/lib/libglib-2.0.so.0
#11 0x00007ffff4458dc8 in ?? () from /usr/lib/libglib-2.0.so.0
#12 0x00007ffff445908a in g_main_loop_run () from /usr/lib/libglib-2.0.so.0
#13 0x00007ffff5ea2417 in gtk_main () from /usr/lib/libgtk-x11-2.0.so.0
#14 0x000000000040890c in main (argc=1, argv=0x7fffffffe388) at daemon.c:1694
(gdb) 

```

Add a sanity check before using the return value.
