### PR TITLE
Fix crash when switching monitors.

### DIFF
--- a/src/daemon/stack.c
+++ b/src/daemon/stack.c
@@ -214,10 +214,17 @@ notify_stack_new (NotifyDaemon       *daemon,
 void
 notify_stack_destroy (NotifyStack *stack)
 {
+        GList* l;
+
         g_assert (stack != NULL);
 
         if (stack->update_id != 0) {
                 g_source_remove (stack->update_id);
+        }
+
+        for (l = stack->windows; l != NULL; l = l->next) {
+                GtkWindow *nw = GTK_WINDOW (l->data);
+                g_signal_handlers_disconnect_by_data(G_OBJECT(nw), stack);
         }
 
         g_list_free (stack->windows);


### PR DESCRIPTION
When switching monitors AND displaying notifications at the
same time, a rare situation might occur when notification
window will be added to two or more stacks. One of the
stacks will be removed soon enough, but the "destroy"
handler will persist and will be triggered when the window
disappears. This results in a reference to a freed memory
and (usually) a daemon crash, a typical one is
https://retrace.fedoraproject.org/faf/reports/359836/ for
example.

So, the removal handlers referring to a deleted stack must
be cancelled prior to removal.
