### PR TITLE
GTK3: Fix positioning notifications with long text

### DIFF
--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -53,6 +53,7 @@
 
 #define MAX_NOTIFICATIONS 20
 
+#define WIDTH 400
 #define IMAGE_SIZE 48
 #define IDLE_SECONDS 30
 #define NOTIFICATION_BUS_NAME      "org.freedesktop.Notifications"
@@ -130,11 +131,31 @@ static void monitor_notification_source_windows(NotifyDaemon* daemon, NotifyTime
 
 G_DEFINE_TYPE(NotifyDaemon, notify_daemon, G_TYPE_OBJECT);
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+static void
+notify_daemon_get_preferred_width (GtkWidget *widget,
+                                   gint *min_width,
+                                   gint *nat_width)
+{
+        if (nat_width != NULL) {
+            *nat_width = WIDTH;
+        }
+}
+#endif
+
 static void notify_daemon_class_init(NotifyDaemonClass* daemon_class)
 {
 	GObjectClass* object_class = G_OBJECT_CLASS(daemon_class);
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (daemon_class);
+#endif
+
 	object_class->finalize = notify_daemon_finalize;
+
+#if GTK_CHECK_VERSION (3, 0, 0)
+    widget_class->get_preferred_width = notify_daemon_get_preferred_width;
+#endif
 
 	g_type_class_add_private(daemon_class, sizeof(NotifyDaemonPrivate));
 }

--- a/src/daemon/stack.c
+++ b/src/daemon/stack.c
@@ -301,7 +301,11 @@ notify_stack_shift_notifications (NotifyStack *stack,
                 GtkRequisition  req;
 
                 if (nw == NULL || nw2 != nw) {
+#if GTK_CHECK_VERSION (3, 0, 0)
+                        gtk_widget_get_preferred_size (GTK_WIDGET (nw2), NULL, &req);
+#else
                         gtk_widget_size_request (GTK_WIDGET (nw2), &req);
+#endif
 
                         translate_coordinates (stack->location,
                                                &workarea,
@@ -362,7 +366,11 @@ void notify_stack_add_window(NotifyStack* stack, GtkWindow* nw, gboolean new_not
 	GtkRequisition  req;
 	gint            x, y;
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+	gtk_widget_get_preferred_size(GTK_WIDGET(nw), NULL, &req);
+#else
 	gtk_widget_size_request(GTK_WIDGET(nw), &req);
+#endif
 	notify_stack_shift_notifications(stack, nw, NULL, req.width, req.height + NOTIFY_STACK_SPACING, &x, &y);
 	theme_move_notification(nw, x, y);
 

--- a/src/themes/coco/coco-theme.c
+++ b/src/themes/coco/coco-theme.c
@@ -471,6 +471,9 @@ create_notification(UrlClickedCb url_clicked)
 	gtk_box_pack_start(GTK_BOX(vbox), windata->summary_label, FALSE, FALSE, 0);
 	gtk_misc_set_alignment(GTK_MISC(windata->summary_label), 0, 0);
 	gtk_label_set_line_wrap(GTK_LABEL(windata->summary_label), TRUE);
+#if GTK_CHECK_VERSION (3, 0, 0)
+	gtk_label_set_line_wrap_mode (GTK_LABEL (windata->summary_label), PANGO_WRAP_WORD_CHAR);
+#endif
 
 	atkobj = gtk_widget_get_accessible(windata->summary_label);
 	atk_object_set_description(atkobj, "Notification summary text.");
@@ -479,6 +482,9 @@ create_notification(UrlClickedCb url_clicked)
 	gtk_box_pack_start(GTK_BOX(vbox), windata->body_label, FALSE, FALSE, 0);
 	gtk_misc_set_alignment(GTK_MISC(windata->body_label), 0, 0);
 	gtk_label_set_line_wrap(GTK_LABEL(windata->body_label), TRUE);
+#if GTK_CHECK_VERSION (3, 0, 0)
+	gtk_label_set_line_wrap_mode (GTK_LABEL (windata->body_label), PANGO_WRAP_WORD_CHAR);
+#endif
 	g_signal_connect(G_OBJECT(windata->body_label), "activate-link",
                          G_CALLBACK(activate_link), windata);
 

--- a/src/themes/nodoka/nodoka-theme.c
+++ b/src/themes/nodoka/nodoka-theme.c
@@ -822,6 +822,9 @@ create_notification(UrlClickedCb url_clicked)
 	gtk_box_pack_start(GTK_BOX(hbox), windata->summary_label, TRUE, TRUE, 0);
 	gtk_misc_set_alignment(GTK_MISC(windata->summary_label), 0, 0);
 	gtk_label_set_line_wrap(GTK_LABEL(windata->summary_label), TRUE);
+#if GTK_CHECK_VERSION (3, 0, 0)
+	gtk_label_set_line_wrap_mode (GTK_LABEL (windata->summary_label), PANGO_WRAP_WORD_CHAR);
+#endif
 
 	atkobj = gtk_widget_get_accessible(windata->summary_label);
 	atk_object_set_description(atkobj, "Notification summary text.");
@@ -868,6 +871,9 @@ create_notification(UrlClickedCb url_clicked)
 	gtk_box_pack_start(GTK_BOX(vbox), windata->body_label, TRUE, TRUE, 0);
 	gtk_misc_set_alignment(GTK_MISC(windata->body_label), 0, 0);
 	gtk_label_set_line_wrap(GTK_LABEL(windata->body_label), TRUE);
+#if GTK_CHECK_VERSION (3, 0, 0)
+	gtk_label_set_line_wrap_mode (GTK_LABEL (windata->body_label), PANGO_WRAP_WORD_CHAR);
+#endif
 	g_signal_connect(G_OBJECT(windata->body_label), "activate-link",
                          G_CALLBACK(activate_link), windata);
 

--- a/src/themes/slider/theme.c
+++ b/src/themes/slider/theme.c
@@ -671,6 +671,9 @@ GtkWindow* create_notification(UrlClickedCb url_clicked)
 	gtk_box_pack_start(GTK_BOX(vbox), windata->summary_label, TRUE, TRUE, 0);
 	gtk_misc_set_alignment(GTK_MISC(windata->summary_label), 0, 0);
 	gtk_label_set_line_wrap(GTK_LABEL(windata->summary_label), TRUE);
+#if GTK_CHECK_VERSION (3, 0, 0)
+	gtk_label_set_line_wrap_mode (GTK_LABEL (windata->summary_label), PANGO_WRAP_WORD_CHAR);
+#endif
 
 	atkobj = gtk_widget_get_accessible(windata->summary_label);
 	atk_object_set_description(atkobj, "Notification summary text.");
@@ -694,6 +697,9 @@ GtkWindow* create_notification(UrlClickedCb url_clicked)
 	gtk_box_pack_start(GTK_BOX(vbox), windata->body_label, TRUE, TRUE, 0);
 	gtk_misc_set_alignment(GTK_MISC(windata->body_label), 0, 0);
 	gtk_label_set_line_wrap(GTK_LABEL(windata->body_label), TRUE);
+#if GTK_CHECK_VERSION (3, 0, 0)
+	gtk_label_set_line_wrap_mode (GTK_LABEL (windata->body_label), PANGO_WRAP_WORD_CHAR);
+#endif
 	g_signal_connect_swapped(G_OBJECT(windata->body_label), "activate-link", G_CALLBACK(windata->url_clicked), win);
 
 	atkobj = gtk_widget_get_accessible(windata->body_label);

--- a/src/themes/standard/theme.c
+++ b/src/themes/standard/theme.c
@@ -718,6 +718,9 @@ GtkWindow* create_notification(UrlClickedCb url_clicked)
 	gtk_box_pack_start(GTK_BOX(hbox), windata->summary_label, TRUE, TRUE, 0);
 	gtk_misc_set_alignment(GTK_MISC(windata->summary_label), 0, 0);
 	gtk_label_set_line_wrap(GTK_LABEL(windata->summary_label), TRUE);
+#if GTK_CHECK_VERSION (3, 0, 0)
+	gtk_label_set_line_wrap_mode (GTK_LABEL (windata->summary_label), PANGO_WRAP_WORD_CHAR);
+#endif
 
 	atkobj = gtk_widget_get_accessible(windata->summary_label);
 	atk_object_set_description(atkobj, "Notification summary text.");
@@ -770,6 +773,9 @@ GtkWindow* create_notification(UrlClickedCb url_clicked)
 	gtk_box_pack_start(GTK_BOX(vbox), windata->body_label, TRUE, TRUE, 0);
 	gtk_misc_set_alignment(GTK_MISC(windata->body_label), 0, 0);
 	gtk_label_set_line_wrap(GTK_LABEL(windata->body_label), TRUE);
+#if GTK_CHECK_VERSION (3, 0, 0)
+	gtk_label_set_line_wrap_mode (GTK_LABEL (windata->body_label), PANGO_WRAP_WORD_CHAR);
+#endif
 	g_signal_connect(G_OBJECT(windata->body_label), "activate-link", G_CALLBACK(activate_link), windata);
 
 	atkobj = gtk_widget_get_accessible(windata->body_label);


### PR DESCRIPTION
If notifications has a long text, they always overlap with the next desktop.

inspired by (but adjusted) from https://git.gnome.org/browse/notification-daemon/commit/?id=44130db13