### PR TITLE
don't use d-bus activation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -253,8 +253,8 @@ AC_SUBST([AM_CXXFLAGS])
 AC_CONFIG_FILES([
 Makefile
 data/Makefile
-data/mate-notification-daemon.desktop.in
 data/mate-notification-daemon-autostart.desktop.in
+data/mate-notification-daemon.desktop.in
 po/Makefile.in
 src/Makefile
 src/daemon/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -180,7 +180,6 @@ AS_AC_EXPAND(DATADIR, $datadir)
 AS_AC_EXPAND(LIBEXECDIR, $libexecdir)
 
 AC_ARG_WITH(dbus-sys, [  --with-dbus-sys=<dir>   where D-BUS system.d directory is])
-AC_ARG_WITH(dbus-services, [  --with-dbus-services=<dir>   where D-BUS services directory is])
 
 if ! test -z "$with_dbus_sys" ; then
 	DBUS_SYS_DIR="$with_dbus_sys"
@@ -188,16 +187,8 @@ else
 	DBUS_SYS_DIR="$SYSCONFDIR/dbus-1/system.d"
 fi
 
-if ! test -z "$with_dbus_services" ; then
-	DBUS_SERVICES_DIR="$with_dbus_services"
-else
-	DBUS_SERVICES_DIR="$DATADIR/dbus-1/services"
-fi
-
 AC_SUBST(DBUS_SYS_DIR)
-AC_SUBST(DBUS_SERVICES_DIR)
 AC_DEFINE_UNQUOTED(DBUS_SYSTEMD_DIR, "$DBUS_SYS_DIR", [Where system.d dir for DBUS is])
-AC_DEFINE_UNQUOTED(DBUS_SERVICES_DIR, "$DBUS_SERVICES_DIR", [Where services dir for DBUS is])
 
 dnl ---------------------------------------------------------------------------
 dnl Turn on the additional warnings last
@@ -262,7 +253,8 @@ AC_SUBST([AM_CXXFLAGS])
 AC_CONFIG_FILES([
 Makefile
 data/Makefile
-data/org.freedesktop.mate.Notifications.service
+data/mate-notification-daemon.desktop.in
+data/mate-notification-daemon-autostart.desktop.in
 po/Makefile.in
 src/Makefile
 src/daemon/Makefile
@@ -288,6 +280,5 @@ echo "
 	cflags:		              ${AM_CFLAGS}
 
 	dbus-1 system.d           $DBUS_SYS_DIR
-	dbus-1 services           $DBUS_SERVICES_DIR
 
 "

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -12,9 +12,16 @@ icon32_DATA = icons/32x32/mate-notification-properties.png
 icon48_DATA = icons/48x48/mate-notification-properties.png
 iconscalable_DATA = icons/scalable/mate-notification-properties.svg
 
+@INTLTOOL_DESKTOP_RULE@
+autostartdir= $(sysconfdir)/xdg/autostart
+autostart_in_in_files = mate-notification-daemon-autostart.desktop.in.in
+autostart_in_files = mate-notification-daemon-autostart.desktop.in
+autostart_DATA = $(autostart_in_files:.desktop.in=.desktop)
 
-servicedir   = $(DBUS_SERVICES_DIR)
-service_DATA = org.freedesktop.mate.Notifications.service
+desktopdir          = $(datadir)/applications
+desktop_in_in_files = mate-notification-daemon.desktop.in.in
+desktop_in_files    = mate-notification-daemon.desktop.in
+desktop_DATA        = $(desktop_in_files:.desktop.in=.desktop)
 
 gsettings_SCHEMAS = org.mate.NotificationDaemon.gschema.xml
 @INTLTOOL_XML_NOMERGE_RULE@
@@ -28,8 +35,9 @@ convert_DATA = mate-notification-daemon.convert
 
 EXTRA_DIST = \
 	$(gsettings_SCHEMAS).in.in \
+	$(autostart_in_in_files) \
+	$(desktop_in_in_files) \
 	$(convert_DATA) \
-	$(service_DATA) \
 	$(icon16_DATA) \
 	$(icon22_DATA) \
 	$(icon24_DATA) \
@@ -37,7 +45,9 @@ EXTRA_DIST = \
 	$(icon48_DATA) \
 	$(iconscalable_DATA)
 
-CLEANFILES = $(gsettings_SCHEMAS)
+CLEANFILES = $(gsettings_SCHEMAS) \
+	$(autostart_DATA) \
+	$(desktop_DATA)
 
 gtk_update_icon_cache = $(UPDATE_ICON_CACHE) -f -t $(datadir)/icons/hicolor
 

--- a/data/mate-notification-daemon-autostart.desktop.in.in
+++ b/data/mate-notification-daemon-autostart.desktop.in.in
@@ -1,0 +1,8 @@
+[Desktop Entry]
+_Name=MATE Notification Daemon
+_Comment=Display notifications
+Exec=@LIBEXECDIR@/mate-notification-daemon
+Terminal=false
+Type=Application
+OnlyShowIn=MATE;
+NoDisplay=true

--- a/data/mate-notification-daemon.desktop.in.in
+++ b/data/mate-notification-daemon.desktop.in.in
@@ -1,0 +1,8 @@
+[Desktop Entry]
+_Name=MATE Notification Daemon
+_Comment=Display notifications
+Exec=@LIBEXECDIR@/mate-notification-daemon
+Terminal=false
+Type=Application
+OnlyShowIn=MATE;
+NoDisplay=true

--- a/data/org.freedesktop.mate.Notifications.service.in
+++ b/data/org.freedesktop.mate.Notifications.service.in
@@ -1,3 +1,0 @@
-[D-BUS Service]
-Name=org.freedesktop.Notifications
-Exec=@LIBEXECDIR@/mate-notification-daemon

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,3 +1,5 @@
+data/mate-notification-daemon-autostart.desktop.in.in
+data/mate-notification-daemon.desktop.in.in
 data/org.mate.NotificationDaemon.gschema.xml.in.in
 src/capplet/mate-notification-properties.c
 src/capplet/mate-notification-properties.desktop.in

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -1,0 +1,2 @@
+data/mate-notification-daemon-autostart.desktop.in
+data/mate-notification-daemon.desktop.in

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -100,7 +100,6 @@ typedef struct {
 struct _NotifyDaemonPrivate {
 	guint next_id;
 	guint timeout_source;
-	guint exit_timeout_source;
 	GHashTable* idle_reposition_notify_ids;
 	GHashTable* monitored_window_hash;
 	GHashTable* notification_hash;
@@ -149,35 +148,6 @@ static void _notify_timeout_destroy(NotifyTimeout* nt)
 	g_signal_handlers_disconnect_by_func(nt->nw, _notification_destroyed_cb, nt->daemon);
 	gtk_widget_destroy(GTK_WIDGET(nt->nw));
 	g_free(nt);
-}
-
-static gboolean do_exit(gpointer user_data)
-{
-	//g_debug("Exiting due to inactivity");
-	exit(1);
-
-	return FALSE;
-}
-
-static void add_exit_timeout(NotifyDaemon* daemon)
-{
-	if (daemon->priv->exit_timeout_source > 0)
-	{
-		return;
-	}
-
-	daemon->priv->exit_timeout_source = g_timeout_add_seconds(IDLE_SECONDS, do_exit, NULL);
-}
-
-static void remove_exit_timeout(NotifyDaemon* daemon)
-{
-	if (daemon->priv->exit_timeout_source == 0)
-	{
-		return;
-	}
-
-	g_source_remove(daemon->priv->exit_timeout_source);
-	daemon->priv->exit_timeout_source = 0;
 }
 
 static void create_stack_for_monitor(NotifyDaemon* daemon, GdkScreen* screen, int monitor_num)
@@ -356,8 +326,6 @@ static void notify_daemon_init(NotifyDaemon* daemon)
 	daemon->priv->next_id = 1;
 	daemon->priv->timeout_source = 0;
 
-	add_exit_timeout(daemon);
-
 	daemon->gsettings = g_settings_new (GSETTINGS_SCHEMA);
 
 	g_signal_connect (daemon->gsettings, "changed::" GSETTINGS_KEY_POPUP_LOCATION, G_CALLBACK (on_popup_location_changed), daemon);
@@ -418,8 +386,6 @@ static void notify_daemon_finalize(GObject* object)
 	{
 		gdk_window_remove_filter(NULL, (GdkFilterFunc) _notify_x11_filter, daemon);
 	}
-
-	remove_exit_timeout(daemon);
 
 	g_hash_table_destroy(daemon->priv->monitored_window_hash);
 	g_hash_table_destroy(daemon->priv->idle_reposition_notify_ids);
@@ -519,10 +485,6 @@ static void _close_notification(NotifyDaemon* daemon, guint id, gboolean hide_no
 
 		g_hash_table_remove(priv->notification_hash, &id);
 
-		if (g_hash_table_size(daemon->priv->notification_hash) == 0)
-		{
-			add_exit_timeout(daemon);
-		}
 	}
 }
 
@@ -740,11 +702,6 @@ static gboolean _check_expiration(NotifyDaemon* daemon)
 	if (!has_more_timeouts)
 	{
 		daemon->priv->timeout_source = 0;
-
-		if (g_hash_table_size (daemon->priv->notification_hash) == 0)
-		{
-			add_exit_timeout(daemon);
-		}
 	}
 
 	return has_more_timeouts;
@@ -822,7 +779,6 @@ static NotifyTimeout* _store_notification(NotifyDaemon* daemon, GtkWindow* nw, i
 	_calculate_timeout(daemon, nt, timeout);
 
 	g_hash_table_insert(priv->notification_hash, g_memdup(&id, sizeof(guint)), nt);
-	remove_exit_timeout(daemon);
 
 	return nt;
 }


### PR DESCRIPTION
if I have mate and xfce, both mate-notification-daemon and xfce4-notifyd works, because both starts via d-bus.

based on
https://git.gnome.org/browse/notification-daemon/commit/?id=1ad20d22098bc7718614a8a87744a2c22d5438d0
https://git.gnome.org/browse/notification-daemon/commit/?id=e05ae7cdc663ce2ea635c11fe78e9c07d2e1c9af
https://git.gnome.org/browse/notification-daemon/commit/?id=219b0af927346c0f29f60c79881a847f5351a6e6
https://git.gnome.org/browse/notification-daemon/commit/?id=fee6ff0cf33ce5bd4c0ac0280cf9dfffcec4b94b
