### PR TITLE
all themes: don't crash on notifications from Rhythmbox

### DIFF
--- a/src/themes/coco/coco-theme.c
+++ b/src/themes/coco/coco-theme.c
@@ -650,7 +650,7 @@ clear_notification_actions(GtkWindow *nw)
 
 	gtk_widget_hide(windata->actions_box);
 	gtk_container_foreach(GTK_CONTAINER(windata->actions_box),
-						  (GtkCallback)g_object_unref, NULL);
+						  (GtkCallback)gtk_widget_destroy, NULL);
 }
 
 /* Move notification window */

--- a/src/themes/nodoka/nodoka-theme.c
+++ b/src/themes/nodoka/nodoka-theme.c
@@ -1047,7 +1047,7 @@ clear_notification_actions(GtkWindow *nw)
 
 	gtk_widget_hide(windata->actions_box);
 	gtk_container_foreach(GTK_CONTAINER(windata->actions_box),
-						  (GtkCallback)g_object_unref, NULL);
+						  (GtkCallback)gtk_widget_destroy, NULL);
 }
 
 /* Move notification window */

--- a/src/themes/slider/theme.c
+++ b/src/themes/slider/theme.c
@@ -1069,7 +1069,7 @@ void clear_notification_actions(GtkWindow* nw)
 	windata->pie_countdown = NULL;
 
 	gtk_widget_hide(windata->actions_box);
-	gtk_container_foreach(GTK_CONTAINER(windata->actions_box), (GtkCallback) g_object_unref, NULL);
+	gtk_container_foreach(GTK_CONTAINER(windata->actions_box), (GtkCallback) gtk_widget_destroy, NULL);
 }
 
 void move_notification(GtkWidget* widget, int x, int y)

--- a/src/themes/standard/theme.c
+++ b/src/themes/standard/theme.c
@@ -1053,7 +1053,7 @@ void clear_notification_actions(GtkWindow* nw)
 	windata->pie_countdown = NULL;
 
 	gtk_widget_hide(windata->actions_box);
-	gtk_container_foreach(GTK_CONTAINER(windata->actions_box), (GtkCallback) g_object_unref, NULL);
+	gtk_container_foreach(GTK_CONTAINER(windata->actions_box), (GtkCallback) gtk_widget_destroy, NULL);
 }
 
 void move_notification(GtkWidget* nw, int x, int y)


### PR DESCRIPTION
fixes https://github.com/mate-desktop/mate-notification-daemon/issues/55

the code used is similar to https://github.com/GNOME/notification-daemon/blob/master/src/nd-bubble.c#L812

@NiceandGently @infirit @flexiondotorg @samtygier
please test for any possible regressions :smile: