### PR TITLE
Themes cleanup and Gtk3 background fixes

### DIFF
--- a/src/themes/coco/coco-theme.c
+++ b/src/themes/coco/coco-theme.c
@@ -276,6 +276,16 @@ countdown_expose_cb(GtkWidget *pie,
 	return TRUE;
 }
 
+static gboolean on_configure_event (GtkWidget* widget, GdkEventConfigure* event, WindowData* windata)
+{
+	windata->width = event->width;
+	windata->height = event->height;
+
+	gtk_widget_queue_draw (widget);
+
+	return FALSE;
+}
+
 static void
 action_clicked_cb(GtkWidget *w, GdkEventButton *event,
 				  ActionInvokedCb action_cb)
@@ -395,6 +405,8 @@ create_notification(UrlClickedCb url_clicked)
 	g_signal_connect(G_OBJECT(main_vbox), "expose_event",
 					 G_CALLBACK(paint_window), windata);
 #endif
+
+	g_signal_connect (G_OBJECT (win), "configure-event", G_CALLBACK (on_configure_event), windata);
 
     padding = gtk_alignment_new(0, 0, 0, 0);
 	gtk_widget_show(padding);

--- a/src/themes/coco/coco-theme.c
+++ b/src/themes/coco/coco-theme.c
@@ -446,7 +446,6 @@ GtkWindow *
 create_notification(UrlClickedCb url_clicked)
 {
 	GtkWidget *win;
-	GtkWidget *drawbox;
 	GtkWidget *main_vbox;
 	GtkWidget *vbox;
 	GtkWidget *alignment;
@@ -501,20 +500,9 @@ create_notification(UrlClickedCb url_clicked)
 	g_signal_connect(G_OBJECT(win), "configure_event",
 					 G_CALLBACK(configure_event_cb), windata);
 
-	/*
-	 * For some reason, there are occasionally graphics glitches when
-	 * repainting the window. Despite filling the window with a background
-	 * color, parts of the other windows on the screen or the shadows around
-	 * notifications will appear on the notification. Somehow, adding this
-	 * eventbox makes that problem just go away. Whatever works for now.
-	 */
-	drawbox = gtk_event_box_new();
-	gtk_widget_show(drawbox);
-	gtk_container_add(GTK_CONTAINER(win), drawbox);
-
 	main_vbox = gtk_vbox_new(FALSE, 0);
 	gtk_widget_show(main_vbox);
-	gtk_container_add(GTK_CONTAINER(drawbox), main_vbox);
+	gtk_container_add (GTK_CONTAINER (win), main_vbox);
 
 #if GTK_CHECK_VERSION (3, 0, 0)
 	g_signal_connect (G_OBJECT (main_vbox), "draw",

--- a/src/themes/coco/coco-theme.c
+++ b/src/themes/coco/coco-theme.c
@@ -45,7 +45,7 @@ typedef struct
 	GtkWidget *stripe_spacer;
 	GtkWidget *pie_countdown;
 
-	gboolean enable_transparency;
+	gboolean composited;
 	
 	int width;
 	int height;
@@ -124,7 +124,7 @@ static void
 fill_background(GtkWidget *widget, WindowData *windata, cairo_t *cr)
 {
 	float alpha;
-	if (windata->enable_transparency)
+	if (windata->composited)
 		alpha = BACKGROUND_OPACITY;
 	else
 		alpha = 1.0;
@@ -353,7 +353,7 @@ create_notification(UrlClickedCb url_clicked)
 	windata->win = win;
 
 	windata->rtl = gtk_widget_get_default_direction();
-	windata->enable_transparency = FALSE;
+	windata->composited = FALSE;
 	screen = gtk_window_get_screen(GTK_WINDOW(win));
 #if GTK_CHECK_VERSION(3, 0, 0)
 	visual = gdk_screen_get_rgba_visual(screen);
@@ -362,7 +362,7 @@ create_notification(UrlClickedCb url_clicked)
 	{
 		gtk_widget_set_visual(win, visual);
 		if (gdk_screen_is_composited(screen))
-			windata->enable_transparency = TRUE;
+			windata->composited = TRUE;
 	}
 #else 
 	colormap = gdk_screen_get_rgba_colormap(screen);
@@ -371,7 +371,7 @@ create_notification(UrlClickedCb url_clicked)
 	{
 		gtk_widget_set_colormap(win, colormap);
 		if (gdk_screen_is_composited(screen))
-			windata->enable_transparency = TRUE;
+			windata->composited = TRUE;
 	}
 #endif
 

--- a/src/themes/nodoka/nodoka-theme.c
+++ b/src/themes/nodoka/nodoka-theme.c
@@ -62,7 +62,7 @@ typedef struct
 
 	ArrowParameters arrow;
 
-	gboolean enable_transparency;
+	gboolean composited;
 	
 	int width;
 	int height;
@@ -355,7 +355,7 @@ static void
 fill_background(GtkWidget *widget, WindowData *windata, cairo_t *cr)
 {
 	float alpha;
-	if (windata->enable_transparency)
+	if (windata->composited)
 		alpha = BACKGROUND_OPACITY;
 	else
 		alpha = 1.0;
@@ -390,7 +390,7 @@ draw_stripe(GtkWidget *widget, WindowData *windata, cairo_t *cr)
 	GdkColor bottom_color;
 
 	float alpha;
-	if (windata->enable_transparency)
+	if (windata->composited)
 		alpha = BACKGROUND_OPACITY;
 	else
 		alpha = 1.0;
@@ -460,7 +460,7 @@ static void
 draw_border(GtkWidget *widget, WindowData *windata, cairo_t *cr)
 {
 	float alpha;
-	if (windata->enable_transparency)
+	if (windata->composited)
 		alpha = BACKGROUND_OPACITY;
 	else
 		alpha = 1.0;
@@ -713,7 +713,7 @@ create_notification(UrlClickedCb url_clicked)
 	win = gtk_window_new(GTK_WINDOW_POPUP);
 	windata->win = win;
 
-	windata->enable_transparency = FALSE;
+	windata->composited = FALSE;
 	screen = gtk_window_get_screen(GTK_WINDOW(win));
 #if GTK_CHECK_VERSION(3, 0, 0)
 	visual = gdk_screen_get_rgba_visual(screen);
@@ -722,7 +722,7 @@ create_notification(UrlClickedCb url_clicked)
 	{
 		gtk_widget_set_visual(win, visual);
 		if (gdk_screen_is_composited(screen))
-			windata->enable_transparency = TRUE;
+			windata->composited = TRUE;
 	}
 #else
 	colormap = gdk_screen_get_rgba_colormap(screen);
@@ -731,7 +731,7 @@ create_notification(UrlClickedCb url_clicked)
 	{
 		gtk_widget_set_colormap(win, colormap);
 		if (gdk_screen_is_composited(screen))
-			windata->enable_transparency = TRUE;
+			windata->composited = TRUE;
 	}
 #endif
 

--- a/src/themes/nodoka/nodoka-theme.c
+++ b/src/themes/nodoka/nodoka-theme.c
@@ -66,6 +66,8 @@ typedef struct
 	
 	int width;
 	int height;
+	int last_width;
+	int last_height;
 
 	guchar urgency;
 	glong timeout;
@@ -499,6 +501,98 @@ draw_pie(GtkWidget *pie, WindowData *windata, cairo_t *cr)
 	cairo_fill (cr); 
 }
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+static void
+update_shape_region (cairo_surface_t *surface,
+		     WindowData      *windata)
+{
+	cairo_region_t *region;
+
+	if (windata->width == windata->last_width && windata->height == windata->last_height)
+	{
+		return;
+	}
+
+	if (windata->width == 0 || windata->height == 0)
+	{
+		GtkAllocation allocation;
+		gtk_widget_get_allocation (windata->win, &allocation);
+
+		windata->width = MAX (allocation.width, 1);
+		windata->height = MAX (allocation.height, 1);
+	}
+
+	if (!windata->composited) {
+		cairo_region_t *region;
+
+		region = gdk_cairo_region_create_from_surface (surface);
+		gtk_widget_shape_combine_region (windata->win, region);
+		cairo_region_destroy (region);
+	} else {
+		gtk_widget_shape_combine_region (windata->win, NULL);
+		return;
+	}
+
+	windata->last_width = windata->width;
+	windata->last_height = windata->height;
+}
+#else
+static void
+update_shape_mask (WindowData* windata)
+{
+	cairo_t *cr;
+	GdkBitmap* mask;
+
+	if (windata->width == windata->last_width && windata->height == windata->last_height)
+	{
+		return;
+	}
+
+	if (windata->width == 0 || windata->height == 0)
+	{
+		GtkAllocation allocation;
+
+		gtk_widget_get_allocation (windata->win, &allocation);
+
+		windata->width = MAX (allocation.width, 1);
+		windata->height = MAX (allocation.height, 1);
+	}
+
+	if (windata->composited)
+	{
+		gtk_widget_shape_combine_mask (windata->win, NULL, 0, 0);
+		return;
+	}
+
+	windata->last_width = windata->width;
+	windata->last_height = windata->height;
+
+	mask = (GdkBitmap*) gdk_pixmap_new (NULL, windata->width, windata->height, 1);
+
+	if (mask == NULL)
+	{
+		return;
+	}
+	cr = gdk_cairo_create (mask);
+
+	if (cairo_status (cr) == CAIRO_STATUS_SUCCESS)
+	{
+		cairo_set_operator (cr, CAIRO_OPERATOR_CLEAR);
+		cairo_paint (cr);
+
+		cairo_set_operator (cr, CAIRO_OPERATOR_OVER);
+		cairo_set_source_rgb (cr, 1.0f, 1.0f, 1.0f);
+		nodoka_rounded_rectangle (cr, 0, 0, windata->width , windata->height, 6);
+		cairo_fill (cr);
+
+		gtk_widget_shape_combine_mask (windata->win, mask, 0, 0);
+	}
+
+	cairo_destroy (cr);
+	g_object_unref (mask);
+}
+#endif
+
 static gboolean
 paint_window(GtkWidget *widget,
 #if GTK_CHECK_VERSION (3, 0, 0)
@@ -563,6 +657,12 @@ paint_window(GtkWidget *widget,
 	cairo_paint (cr);
 	cairo_restore (cr);
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+	update_shape_region (surface, windata);
+#else
+	update_shape_mask (windata);
+#endif
+
 #if !GTK_CHECK_VERSION (3, 0, 0)
 	cairo_destroy(cr);
 #endif
@@ -584,6 +684,13 @@ configure_event_cb(GtkWidget *nw,
 	gtk_widget_queue_draw(nw);
 
 	return FALSE;
+}
+
+static void on_composited_changed (GtkWidget* window, WindowData* windata)
+{
+	windata->composited = gdk_screen_is_composited (gtk_widget_get_screen(window));
+
+	gtk_widget_queue_draw (window);
 }
 
 static gboolean
@@ -731,6 +838,8 @@ create_notification(UrlClickedCb url_clicked)
 
 	g_signal_connect(G_OBJECT(win), "configure_event",
 					 G_CALLBACK(configure_event_cb), windata);
+
+	g_signal_connect (G_OBJECT (win), "composited-changed", G_CALLBACK (on_composited_changed), windata);
 
 	/*
 	 * For some reason, there are occasionally graphics glitches when

--- a/src/themes/nodoka/nodoka-theme.c
+++ b/src/themes/nodoka/nodoka-theme.c
@@ -799,7 +799,6 @@ create_notification(UrlClickedCb url_clicked)
 {
 	GtkWidget *spacer;
 	GtkWidget *win;
-	GtkWidget *drawbox;
 	GtkWidget *main_vbox;
 	GtkWidget *hbox;
 	GtkWidget *vbox;
@@ -858,20 +857,9 @@ create_notification(UrlClickedCb url_clicked)
 
 	g_signal_connect (G_OBJECT (win), "composited-changed", G_CALLBACK (on_composited_changed), windata);
 
-	/*
-	 * For some reason, there are occasionally graphics glitches when
-	 * repainting the window. Despite filling the window with a background
-	 * color, parts of the other windows on the screen or the shadows around
-	 * notifications will appear on the notification. Somehow, adding this
-	 * eventbox makes that problem just go away. Whatever works for now.
-	 */
-	drawbox = gtk_event_box_new();
-	gtk_widget_show(drawbox);
-	gtk_container_add(GTK_CONTAINER(win), drawbox);
-
 	main_vbox = gtk_vbox_new(FALSE, 0);
 	gtk_widget_show(main_vbox);
-	gtk_container_add(GTK_CONTAINER(drawbox), main_vbox);
+	gtk_container_add(GTK_CONTAINER(win), main_vbox);
 	gtk_container_set_border_width(GTK_CONTAINER(main_vbox), 1);
 
 #if GTK_CHECK_VERSION (3, 0, 0)

--- a/src/themes/nodoka/nodoka-theme.c
+++ b/src/themes/nodoka/nodoka-theme.c
@@ -387,9 +387,17 @@ draw_stripe(GtkWidget *widget, WindowData *windata, cairo_t *cr)
 	cairo_rectangle (cr, 0, 0, STRIPE_WIDTH, windata->height);
 	cairo_clip (cr);
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+	gdouble  color_mult = 1.0;
+	GdkRGBA  top_color;
+	GdkRGBA  center_color;
+	GdkRGBA  bottom_color;
+#else
+	gdouble  color_mult = 65535.0;
 	GdkColor top_color;
 	GdkColor center_color;
 	GdkColor bottom_color;
+#endif
 
 	float alpha;
 	if (windata->composited)
@@ -401,49 +409,49 @@ draw_stripe(GtkWidget *widget, WindowData *windata, cairo_t *cr)
 	{
 		case URGENCY_LOW: // LOW
 			alpha = alpha * 0.5;
-			top_color.red = 221 / 255.0 * 65535.0;
+			top_color.red = 221 / 255.0 * color_mult;
 			top_color.green = top_color.red;
 			top_color.blue = top_color.red;
-			center_color.red = 192 / 255.0 * 65535.0;
+			center_color.red = 192 / 255.0 * color_mult;
 			center_color.green = center_color.red;
 			center_color.blue = center_color.red;
-			bottom_color.red = 167 / 255.0 * 65535.0;
+			bottom_color.red = 167 / 255.0 * color_mult;
 			bottom_color.green = center_color.red;
 			bottom_color.blue = center_color.red;
 			break;
 
 		case URGENCY_CRITICAL: // CRITICAL
-			top_color.red = 255 / 255.0 * 65535.0;
-			top_color.green = 11 / 255.0 * 65535.0;
+			top_color.red = 255 / 255.0 * color_mult;
+			top_color.green = 11 / 255.0 * color_mult;
 			top_color.blue = top_color.green;
-			center_color.red = 205 / 255.0 * 65535.0;
+			center_color.red = 205 / 255.0 * color_mult;
 			center_color.green = 0;
 			center_color.blue = 0;
-			bottom_color.red = 145 / 255.0 * 65535.0;
+			bottom_color.red = 145 / 255.0 * color_mult;
 			bottom_color.green = 0;
 			bottom_color.blue = 0;
 			break;
 
 		case URGENCY_NORMAL: // NORMAL
 		default:
-			top_color.red = 20 / 255.0 * 65535.0;
-			top_color.green = 175 / 255.0 * 65535.0;
-			top_color.blue = 65535.0;
-			center_color.red = 9 / 255.0 * 65535.0;
-			center_color.green = 139 / 255.0 * 65535.0;
-			center_color.blue = 207 / 255.0 * 65535.0;
+			top_color.red = 20 / 255.0 * color_mult;
+			top_color.green = 175 / 255.0 * color_mult;
+			top_color.blue = color_mult;
+			center_color.red = 9 / 255.0 * color_mult;
+			center_color.green = 139 / 255.0 * color_mult;
+			center_color.blue = 207 / 255.0 * color_mult;
 			bottom_color.red = 0;
-			bottom_color.green = 97 / 255.0 * 65535.0;
-			bottom_color.blue = 147 / 255.0 * 65535.0;
+			bottom_color.green = 97 / 255.0 * color_mult;
+			bottom_color.blue = 147 / 255.0 * color_mult;
 			break;
 	}
 
 
 	cairo_pattern_t *pattern;
 	pattern = cairo_pattern_create_linear (0, 0, 0, windata->height);
-	cairo_pattern_add_color_stop_rgba (pattern, 0, top_color.red / 65535.0, top_color.green / 65535.0, top_color.blue / 65535.0, alpha);
-	cairo_pattern_add_color_stop_rgba (pattern, GRADIENT_CENTER, bottom_color.red / 65535.0, bottom_color.green / 65535.0, bottom_color.blue / 65535.0, alpha);
-	cairo_pattern_add_color_stop_rgba (pattern, 1, bottom_color.red / 65535.0, bottom_color.green / 65535.0, bottom_color.blue / 65535.0, alpha);
+	cairo_pattern_add_color_stop_rgba (pattern, 0, top_color.red / color_mult, top_color.green / color_mult, top_color.blue / color_mult, alpha);
+	cairo_pattern_add_color_stop_rgba (pattern, GRADIENT_CENTER, bottom_color.red / color_mult, bottom_color.green / color_mult, bottom_color.blue / color_mult, alpha);
+	cairo_pattern_add_color_stop_rgba (pattern, 1, bottom_color.red / color_mult, bottom_color.green / color_mult, bottom_color.blue / color_mult, alpha);
 	cairo_set_source (cr, pattern);
 	cairo_pattern_destroy (pattern);
 

--- a/src/themes/slider/theme.c
+++ b/src/themes/slider/theme.c
@@ -132,7 +132,7 @@ static void fill_background(GtkWidget* widget, WindowData* windata, cairo_t* cr)
 #if GTK_CHECK_VERSION(3, 0, 0)
 	context = gtk_widget_get_style_context(widget);
 
-	gtk_style_context_get_background_color (context, GTK_STATE_FLAG_NORMAL, &bg_color);
+	gtk_style_context_get (context, GTK_STATE_FLAG_NORMAL, "background-color", &bg_color, NULL);
 	r = bg_color.red;
 	g = bg_color.green;
 	b = bg_color.blue;
@@ -447,7 +447,7 @@ static void override_style(GtkWidget* widget)
 		flags = state_flags_from_type (state);
 
 		gtk_style_context_get_color (context, flags, &fg);
-		gtk_style_context_get_background_color (context, flags, &bg);
+		gtk_style_context_get (context, flags, "background-color", &bg, NULL);
 
 		color_reverse(&fg, &fg2);
 		color_reverse(&bg, &bg2);
@@ -948,7 +948,7 @@ static gboolean on_countdown_expose(GtkWidget* pie, GdkEventExpose* event, Windo
 	cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
 #if GTK_CHECK_VERSION (3, 0, 0)
 	gtk_style_context_get_color (context, GTK_STATE_FLAG_NORMAL, &color);
-	gtk_style_context_get_background_color (context, GTK_STATE_FLAG_NORMAL, &fg_color);
+	gtk_style_context_get (context, GTK_STATE_FLAG_NORMAL, "background-color", &fg_color, NULL);
 	r = color.red;
 	g = color.green;
 	b = color.blue;

--- a/src/themes/standard/theme.c
+++ b/src/themes/standard/theme.c
@@ -474,18 +474,14 @@ static void draw_border(GtkWidget* widget, WindowData *windata, cairo_t* cr)
 	cairo_stroke(cr);
 }
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-static gboolean paint_window(GtkWidget* widget, cairo_t* cr, WindowData* windata)
-#else
-static gboolean paint_window(GtkWidget* widget, GdkEventExpose* event, WindowData* windata)
-#endif
+static void
+paint_window (GtkWidget  *widget,
+	      cairo_t    *cr,
+	      WindowData *windata)
 {
 	cairo_t*         cr2;
 	cairo_surface_t* surface;
 	GtkAllocation    allocation;
-#if !GTK_CHECK_VERSION(3, 0, 0)
-	cairo_t*         cr = gdk_cairo_create (event->window);
-#endif
 
 	gtk_widget_get_allocation(windata->win, &allocation);
 
@@ -515,12 +511,28 @@ static gboolean paint_window(GtkWidget* widget, GdkEventExpose* event, WindowDat
 	cairo_set_source_surface (cr, surface, 0, 0);
 	cairo_paint(cr);
 	cairo_surface_destroy(surface);
+}
 
-#if !GTK_CHECK_VERSION (3, 0, 0)
-	cairo_destroy(cr);
-#endif
+static gboolean
+#if GTK_CHECK_VERSION (3, 0, 0)
+on_draw (GtkWidget *widget, cairo_t *cr, WindowData *windata)
+{
+	paint_window (widget, cr, windata);
+
 	return FALSE;
 }
+#else
+on_expose_event (GtkWidget *widget, GdkEventExpose *event, WindowData *windata)
+{
+	cairo_t *cr = gdk_cairo_create (event->window);
+
+	paint_window (widget, cr, windata);
+
+	cairo_destroy (cr);
+
+	return FALSE;
+}
+#endif
 
 static void destroy_windata(WindowData* windata)
 {
@@ -687,9 +699,9 @@ GtkWindow* create_notification(UrlClickedCb url_clicked)
 	gtk_container_set_border_width(GTK_CONTAINER(main_vbox), 1);
 
 #if GTK_CHECK_VERSION (3, 0, 0)
-	g_signal_connect(G_OBJECT(main_vbox), "draw", G_CALLBACK(paint_window), windata);
+	g_signal_connect (G_OBJECT (main_vbox), "draw", G_CALLBACK (on_draw), windata);
 #else
-	g_signal_connect(G_OBJECT(main_vbox), "expose_event", G_CALLBACK(paint_window), windata);
+	g_signal_connect (G_OBJECT (main_vbox), "expose_event", G_CALLBACK (on_expose_event), windata);
 #endif
 
 	windata->top_spacer = gtk_image_new();

--- a/src/themes/standard/theme.c
+++ b/src/themes/standard/theme.c
@@ -43,7 +43,7 @@ typedef struct {
 	GtkWidget* pie_countdown;
 
 	gboolean has_arrow;
-	gboolean enable_transparency;
+	gboolean composited;
 
 	int point_x;
 	int point_y;
@@ -129,7 +129,7 @@ static void fill_background(GtkWidget* widget, WindowData* windata, cairo_t* cr)
 	style = gtk_widget_get_style(widget);
 	background_color = &style->base[GTK_STATE_NORMAL];
 
-	if (windata->enable_transparency)
+	if (windata->composited)
 	{
 		cairo_set_source_rgba(cr, background_color->red / 65535.0, background_color->green / 65535.0, background_color->blue / 65535.0, BACKGROUND_OPACITY);
 	}
@@ -634,7 +634,7 @@ GtkWindow* create_notification(UrlClickedCb url_clicked)
 	win = gtk_window_new(GTK_WINDOW_POPUP);
 	windata->win = win;
 
-	windata->enable_transparency = FALSE;
+	windata->composited = FALSE;
 
 
 	screen = gtk_window_get_screen(GTK_WINDOW(win));
@@ -648,7 +648,7 @@ GtkWindow* create_notification(UrlClickedCb url_clicked)
 
 		if (gdk_screen_is_composited(screen))
 		{
-			windata->enable_transparency = TRUE;
+			windata->composited = TRUE;
 		}
 	}
 #else
@@ -657,7 +657,7 @@ GtkWindow* create_notification(UrlClickedCb url_clicked)
 	if (colormap != NULL && gdk_screen_is_composited(screen))
 	{
 		gtk_widget_set_colormap(win, colormap);
-		windata->enable_transparency = TRUE;
+		windata->composited = TRUE;
 	}
 #endif
 

--- a/src/themes/standard/theme.c
+++ b/src/themes/standard/theme.c
@@ -480,11 +480,11 @@ static gboolean paint_window(GtkWidget* widget, cairo_t* cr, WindowData* windata
 static gboolean paint_window(GtkWidget* widget, GdkEventExpose* event, WindowData* windata)
 #endif
 {
-	cairo_t*         context;
+	cairo_t*         cr2;
 	cairo_surface_t* surface;
 	GtkAllocation    allocation;
 #if !GTK_CHECK_VERSION(3, 0, 0)
-	cairo_t*         cr;
+	cairo_t*         cr = gdk_cairo_create (event->window);
 #endif
 
 	gtk_widget_get_allocation(windata->win, &allocation);
@@ -495,32 +495,30 @@ static gboolean paint_window(GtkWidget* widget, GdkEventExpose* event, WindowDat
 			windata->height = allocation.height;
 	}
 
-	context = gdk_cairo_create(gtk_widget_get_window(widget));
-
-	cairo_set_operator(context, CAIRO_OPERATOR_SOURCE);
+	cairo_set_operator(cr, CAIRO_OPERATOR_SOURCE);
 
 	gtk_widget_get_allocation(widget, &allocation);
 
-	surface = cairo_surface_create_similar(cairo_get_target(context), CAIRO_CONTENT_COLOR_ALPHA, allocation.width, allocation.height);
+	surface = cairo_surface_create_similar (cairo_get_target (cr),
+						CAIRO_CONTENT_COLOR_ALPHA,
+						allocation.width,
+						allocation.height);
 
-#if GTK_CHECK_VERSION (3, 0, 0)
-	cairo_set_source_surface(cr, surface, 0, 0);
-#else
-	cr = cairo_create(surface);
-#endif
+	cr2 = cairo_create (surface);
 
-	fill_background(widget, windata, cr);
-	draw_border(widget, windata, cr);
-	draw_stripe(widget, windata, cr);
+	fill_background(widget, windata, cr2);
+	draw_border(widget, windata, cr2);
+	draw_stripe(widget, windata, cr2);
+	cairo_fill (cr2);
+	cairo_destroy (cr2);
+
+	cairo_set_source_surface (cr, surface, 0, 0);
+	cairo_paint(cr);
+	cairo_surface_destroy(surface);
 
 #if !GTK_CHECK_VERSION (3, 0, 0)
 	cairo_destroy(cr);
 #endif
-	cairo_set_source_surface(context, surface, 0, 0);
-	cairo_paint(context);
-	cairo_surface_destroy(surface);
-	cairo_destroy(context);
-
 	return FALSE;
 }
 


### PR DESCRIPTION
Let me first tell folks what I think is important. The most important is that there are no __regressions__ when using notification daemon under __Gtk+2__. I could not find anything that was not already broken :smiling_imp:.

Now for the fun stuff, all the themes now render a proper background under Gtk+3. However... there are still some things not working right. But I do not want to delay sending this off to master as this makes most of the themes usable under Gtk+3.

* Except for slider the height is wrong. If anyone has a clue do let me know.
* For some reason when under non composited Gtk3 shaping of the round themes sometimes is delayed.
* Slider text colour is not right and in some cases as good as unreadable (dark gray on black).