### PR TITLE
Implement listening on setting sound-enabled change 

### DIFF
--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -1382,7 +1382,7 @@ static void sync_notification_position(NotifyDaemon* daemon, GtkWindow* nw, Wind
 
 GQuark notify_daemon_error_quark(void)
 {
-	static GQuark q = 0;
+	static GQuark q;
 
 	if (q == 0)
 	{

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -1755,7 +1755,7 @@ int main(int argc, char** argv)
 	gboolean res;
 	guint request_name_result;
 
-	g_log_set_always_fatal(G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL);
+	g_log_set_always_fatal(G_LOG_LEVEL_CRITICAL);
 
 	gtk_init(&argc, &argv);
 

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -121,7 +121,7 @@ typedef struct {
 	NotifyDaemon* daemon;
 } _NotifyPendingClose;
 
-static DBusConnection* dbus_conn = NULL;
+static DBusConnection* dbus_conn;
 
 static void notify_daemon_finalize(GObject* object);
 static void _notification_destroyed_cb(GtkWindow* nw, NotifyDaemon* daemon);

--- a/src/daemon/sound.c
+++ b/src/daemon/sound.c
@@ -30,7 +30,7 @@ void
 sound_play_file (GtkWidget *widget,
                  const char *filename)
 {
-        ca_gtk_play_for_widget (widget, 0,
+        ca_gtk_play_for_widget (widget, MATE_EVENT,
                                 CA_PROP_MEDIA_ROLE, "event",
                                 CA_PROP_MEDIA_FILENAME, filename,
                                 CA_PROP_EVENT_DESCRIPTION, _("Notification"),

--- a/src/daemon/sound.h
+++ b/src/daemon/sound.h
@@ -24,6 +24,8 @@
 
 #include <gtk/gtk.h>
 
+#define MATE_EVENT 42
+
 void sound_play_file(GtkWidget* widget, const char* filename);
 
 #endif /* _SOUND_H */


### PR DESCRIPTION
My first try to implement something useful in mate-notification-daemon :P

This is a try to fix one of the items listed on #49.

How do we solve that?
If sound-enabled becomes disabled then simply mute all playing sounds. On the other hand when it becomes enabled it is harder. Solve this by creating a linked list of format (notification_id, sound_file). So when it becomes enabled play all sound files from that list. Also, don't forget to remove the corresponding element from that list when a notification closes.