### PR TITLE
daemon: fix memory leak in on_popup_location_changed()

### DIFF
--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -127,7 +127,7 @@ static void _close_notification(NotifyDaemon* daemon, guint id, gboolean hide_no
 static GdkFilterReturn _notify_x11_filter(GdkXEvent* xevent, GdkEvent* event, NotifyDaemon* daemon);
 static void _emit_closed_signal(GtkWindow* nw, NotifydClosedReason reason);
 static void _action_invoked_cb(GtkWindow* nw, const char* key);
-static NotifyStackLocation get_stack_location_from_string(gchar *slocation);
+static NotifyStackLocation get_stack_location_from_string(const gchar *slocation);
 static void sync_notification_position(NotifyDaemon* daemon, GtkWindow* nw, Window source);
 static void monitor_notification_source_windows(NotifyDaemon* daemon, NotifyTimeout* nt, Window source);
 
@@ -527,7 +527,7 @@ static void notify_daemon_finalize(GObject* object)
 	G_OBJECT_CLASS(notify_daemon_parent_class)->finalize(object);
 }
 
-static NotifyStackLocation get_stack_location_from_string(gchar *slocation)
+static NotifyStackLocation get_stack_location_from_string(const gchar *slocation)
 {
 	NotifyStackLocation stack_location = NOTIFY_STACK_LOCATION_DEFAULT;
 

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -127,7 +127,7 @@ static void _close_notification(NotifyDaemon* daemon, guint id, gboolean hide_no
 static GdkFilterReturn _notify_x11_filter(GdkXEvent* xevent, GdkEvent* event, NotifyDaemon* daemon);
 static void _emit_closed_signal(GtkWindow* nw, NotifydClosedReason reason);
 static void _action_invoked_cb(GtkWindow* nw, const char* key);
-static NotifyStackLocation get_stack_location_from_string(const char* slocation);
+static NotifyStackLocation get_stack_location_from_string(gchar *slocation);
 static void sync_notification_position(NotifyDaemon* daemon, GtkWindow* nw, Window source);
 static void monitor_notification_source_windows(NotifyDaemon* daemon, NotifyTimeout* nt, Window source);
 
@@ -359,7 +359,7 @@ static void create_screens(NotifyDaemon* daemon)
 static void on_popup_location_changed(GSettings *settings, gchar *key, NotifyDaemon* daemon)
 {
 	NotifyStackLocation stack_location;
-	const char* slocation;
+	gchar *slocation;
 	int i;
 
 	slocation = g_settings_get_string(daemon->gsettings, key);
@@ -376,6 +376,7 @@ static void on_popup_location_changed(GSettings *settings, gchar *key, NotifyDae
 	}
 
 	daemon->priv->stack_location = stack_location;
+	g_free(slocation);
 
 #if GTK_CHECK_VERSION (3, 8, 0)
     NotifyScreen *nscreen;
@@ -526,7 +527,7 @@ static void notify_daemon_finalize(GObject* object)
 	G_OBJECT_CLASS(notify_daemon_parent_class)->finalize(object);
 }
 
-static NotifyStackLocation get_stack_location_from_string(const char* slocation)
+static NotifyStackLocation get_stack_location_from_string(gchar *slocation)
 {
 	NotifyStackLocation stack_location = NOTIFY_STACK_LOCATION_DEFAULT;
 


### PR DESCRIPTION
Don't forget to free the result of g_settings_get_string(). Also, change
`slocation' to proper type gchar* for storing results of
g_settings_get_string(). Furthermore, this allows to use that pointer in free()
without any casting.