### PR TITLE
Nodoka: use a fixed font color

### DIFF
--- a/src/themes/nodoka/nodoka-theme.c
+++ b/src/themes/nodoka/nodoka-theme.c
@@ -1004,11 +1004,15 @@ set_notification_text(GtkWindow *nw, const char *summary, const char *body)
 	WindowData *windata = g_object_get_data(G_OBJECT(nw), "windata");
 	g_assert(windata != NULL);
 
-	str = g_strdup_printf("<b><big>%s</big></b>", summary);
+	str = g_strdup_printf(
+		"<span color=\"#000000\"><b><big>%s</big></b></span>", summary);
 	gtk_label_set_markup(GTK_LABEL(windata->summary_label), str);
 	g_free(str);
 
-	gtk_label_set_markup(GTK_LABEL(windata->body_label), body);
+	str = g_strdup_printf(
+        "<span color=\"#000000\">%s</span>", body);
+	gtk_label_set_markup(GTK_LABEL(windata->body_label), str);
+	g_free(str);
 
 	if (body == NULL || *body == '\0')
 		gtk_widget_hide(windata->body_label);


### PR DESCRIPTION
fixes https://github.com/mate-desktop/mate-notification-daemon/issues/86

Currenty the theme use the font color from gtk theme,
which give us unreadable notifications text in case of
using a dark gtk theme with mostly light font colors.