### PR TITLE
coco: fix window height in gtk3 builds

### DIFF
--- a/src/themes/coco/coco-theme.c
+++ b/src/themes/coco/coco-theme.c
@@ -404,7 +404,12 @@ countdown_expose_cb(GtkWidget *pie,
 static gboolean on_configure_event (GtkWidget* widget, GdkEventConfigure* event, WindowData* windata)
 {
 	windata->width = event->width;
+	/* fix window height in GTK3 */
+#if GTK_CHECK_VERSION(3, 0, 0)
+	windata->height = event->height/2.2;
+#else
 	windata->height = event->height;
+#endif
 
 	gtk_widget_queue_draw (widget);
 


### PR DESCRIPTION
Reduce the height of the notification window in gtk3 builds to one proportionate to the window contents. In most cases this will prevent the notification window from overlapping bottom panels. Not all notifications send the window to the exact same place so a few cases such as notify-send can still overlap a bottom panel but with no loss of usability.