### PR TITLE
coco: fix gtk3 window height the right way

### DIFF
--- a/src/themes/coco/coco-theme.c
+++ b/src/themes/coco/coco-theme.c
@@ -478,6 +478,7 @@ create_notification(UrlClickedCb url_clicked)
 	windata->url_clicked = url_clicked;
 
 	win = gtk_window_new(GTK_WINDOW_POPUP);
+	gtk_window_set_resizable(GTK_WINDOW(win), FALSE);
 	windata->win = win;
 
 	windata->rtl = gtk_widget_get_default_direction();


### PR DESCRIPTION
Coco:fix the height of the entire notification window in gtk3 builds, not just the visible area This gives consistant position no matter what the height of the notification window, and never overlaps the panel regardless of panel position. Top, bottom, left, right panels tested along with top left, top right, bottom left, and bottom right notification locations. None overlapped, consistant spacing from notification window to panel in all cases-just like slider.  The previous "fix" has been reverted and is not present in this commit.