### PR TITLE
Implement Action icons Support

### DIFF
--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -1610,6 +1610,7 @@ gboolean notify_daemon_get_capabilities(NotifyDaemon* daemon, char*** caps)
 {
 	GPtrArray* a = g_ptr_array_new ();
 	g_ptr_array_add (a, g_strdup ("actions"));
+	g_ptr_array_add (a, g_strdup ("action-icons"));
 	g_ptr_array_add (a, g_strdup ("body"));
 	g_ptr_array_add (a, g_strdup ("body-hyperlinks"));
 	g_ptr_array_add (a, g_strdup ("body-markup"));

--- a/src/themes/coco/coco-theme.c
+++ b/src/themes/coco/coco-theme.c
@@ -578,15 +578,18 @@ add_notification_action(GtkWindow *nw, const char *text, const char *key,
 	{
 		gtk_widget_show(windata->actions_box);
 
-		windata->pie_countdown = gtk_drawing_area_new();
-		gtk_widget_set_halign (windata->pie_countdown, GTK_ALIGN_END);
-		gtk_widget_show(windata->pie_countdown);
+		/* Don't try to re-add a pie_countdown */
+		if (!windata->pie_countdown) {
+			windata->pie_countdown = gtk_drawing_area_new();
+			gtk_widget_set_halign (windata->pie_countdown, GTK_ALIGN_END);
+			gtk_widget_show(windata->pie_countdown);
 
-		gtk_box_pack_end (GTK_BOX (windata->actions_box), windata->pie_countdown, FALSE, TRUE, 0);
-		gtk_widget_set_size_request(windata->pie_countdown,
-									PIE_WIDTH, PIE_HEIGHT);
-		g_signal_connect(G_OBJECT(windata->pie_countdown), "draw",
-						 G_CALLBACK(countdown_expose_cb), windata);
+			gtk_box_pack_end (GTK_BOX (windata->actions_box), windata->pie_countdown, FALSE, TRUE, 0);
+			gtk_widget_set_size_request(windata->pie_countdown,
+						    PIE_WIDTH, PIE_HEIGHT);
+			g_signal_connect(G_OBJECT(windata->pie_countdown), "draw",
+					 G_CALLBACK(countdown_expose_cb), windata);
+		}
 	}
 
 	button = gtk_button_new();

--- a/src/themes/coco/coco-theme.c
+++ b/src/themes/coco/coco-theme.c
@@ -47,7 +47,8 @@ typedef struct
 	GtkWidget *pie_countdown;
 
 	gboolean composited;
-	
+	gboolean action_icons;
+
 	int width;
 	int height;
 	int last_width;
@@ -680,11 +681,12 @@ void
 set_notification_hints(GtkWindow *nw, GHashTable *hints)
 {
 	WindowData *windata = g_object_get_data(G_OBJECT(nw), "windata");
-	GValue *value;
+	GValue *value = NULL, *icon_value = NULL;
 
 	g_assert(windata != NULL);
 
 	value = (GValue *)g_hash_table_lookup(hints, "urgency");
+	icon_value = (GValue *)g_hash_table_lookup(hints, "action-icons");
 
 	if (value != NULL && G_VALUE_HOLDS_UCHAR(value))
 	{
@@ -695,6 +697,12 @@ set_notification_hints(GtkWindow *nw, GHashTable *hints)
 		} else {
 			gtk_window_set_title(GTK_WINDOW(nw), "Notification");
 		}
+	}
+
+	/* Determine if action-icons have been requested */
+	if (icon_value != NULL && G_VALUE_HOLDS_BOOLEAN(icon_value))
+	{
+		windata->action_icons = g_value_get_boolean(icon_value);
 	}
 }
 

--- a/src/themes/coco/coco-theme.c
+++ b/src/themes/coco/coco-theme.c
@@ -592,9 +592,12 @@ add_notification_action(GtkWindow *nw, const char *text, const char *key,
 		}
 	}
 
+	if (windata->action_icons) {
+		button = gtk_button_new_from_icon_name(key, GTK_ICON_SIZE_BUTTON);
+		goto add_button;
+	}
+
 	button = gtk_button_new();
-	gtk_widget_show(button);
-	gtk_box_pack_start(GTK_BOX(windata->actions_box), button, FALSE, FALSE, 0);
 
 	hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 6);
 	gtk_widget_show(hbox);
@@ -630,11 +633,17 @@ add_notification_action(GtkWindow *nw, const char *text, const char *key,
 	gtk_label_set_markup(GTK_LABEL(label), buf);
 	g_free(buf);
 
+add_button:
+	gtk_widget_show(button);
+	gtk_box_pack_start(GTK_BOX(windata->actions_box), button, FALSE, FALSE, 0);
+
 	g_object_set_data(G_OBJECT(button), "_nw", nw);
 	g_object_set_data_full(G_OBJECT(button),
 						   "_action_key", g_strdup(key), g_free);
 	g_signal_connect(G_OBJECT(button), "button-release-event",
 					 G_CALLBACK(action_clicked_cb), cb);
+
+	gtk_widget_show_all(windata->actions_box);
 }
 
 /* Clear notification actions */

--- a/src/themes/nodoka/nodoka-theme.c
+++ b/src/themes/nodoka/nodoka-theme.c
@@ -975,15 +975,18 @@ add_notification_action(GtkWindow *nw, const char *text, const char *key,
 		gtk_widget_show(windata->actions_box);
 		update_content_hbox_visibility(windata);
 
-		windata->pie_countdown = gtk_drawing_area_new();
-		gtk_widget_set_halign (windata->pie_countdown, GTK_ALIGN_END);
-		gtk_widget_show(windata->pie_countdown);
+		/* Don't try to re-add a pie_countdown */
+		if (!windata->pie_countdown) {
+			windata->pie_countdown = gtk_drawing_area_new();
+			gtk_widget_set_halign (windata->pie_countdown, GTK_ALIGN_END);
+			gtk_widget_show(windata->pie_countdown);
 
-		gtk_box_pack_end (GTK_BOX (windata->actions_box), windata->pie_countdown, FALSE, TRUE, 0);
-		gtk_widget_set_size_request(windata->pie_countdown,
-									PIE_WIDTH, PIE_HEIGHT);
-		g_signal_connect(G_OBJECT(windata->pie_countdown), "draw",
-						 G_CALLBACK(countdown_expose_cb), windata);
+			gtk_box_pack_end (GTK_BOX (windata->actions_box), windata->pie_countdown, FALSE, TRUE, 0);
+			gtk_widget_set_size_request(windata->pie_countdown,
+						    PIE_WIDTH, PIE_HEIGHT);
+			g_signal_connect(G_OBJECT(windata->pie_countdown), "draw",
+					 G_CALLBACK(countdown_expose_cb), windata);
+		}
 	}
 
 	button = gtk_button_new();

--- a/src/themes/nodoka/nodoka-theme.c
+++ b/src/themes/nodoka/nodoka-theme.c
@@ -64,7 +64,8 @@ typedef struct
 	ArrowParameters arrow;
 
 	gboolean composited;
-	
+	gboolean action_icons;
+
 	int width;
 	int height;
 	int last_width;
@@ -1084,11 +1085,12 @@ void
 set_notification_hints(GtkWindow *nw, GHashTable *hints)
 {
 	WindowData *windata = g_object_get_data(G_OBJECT(nw), "windata");
-	GValue *value;
+	GValue *value = NULL, *icon_value = NULL;
 
 	g_assert(windata != NULL);
 
 	value = (GValue *)g_hash_table_lookup(hints, "urgency");
+	icon_value = (GValue *)g_hash_table_lookup(hints, "action-icons");
 
 	if (value != NULL && G_VALUE_HOLDS_UCHAR(value))
 	{
@@ -1099,6 +1101,12 @@ set_notification_hints(GtkWindow *nw, GHashTable *hints)
 		} else {
 			gtk_window_set_title(GTK_WINDOW(nw), "Notification");
 		}
+	}
+
+	/* Determine if action-icons have been requested */
+	if (icon_value != NULL && G_VALUE_HOLDS_BOOLEAN(icon_value))
+	{
+		windata->action_icons = g_value_get_boolean(icon_value);
 	}
 }
 

--- a/src/themes/nodoka/nodoka-theme.c
+++ b/src/themes/nodoka/nodoka-theme.c
@@ -989,9 +989,12 @@ add_notification_action(GtkWindow *nw, const char *text, const char *key,
 		}
 	}
 
+	if (windata->action_icons) {
+		button = gtk_button_new_from_icon_name(key, GTK_ICON_SIZE_BUTTON);
+		goto add_button;
+	}
+
 	button = gtk_button_new();
-	gtk_widget_show(button);
-	gtk_box_pack_start(GTK_BOX(windata->actions_box), button, FALSE, FALSE, 0);
 
 	hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 6);
 	gtk_widget_show(hbox);
@@ -1027,11 +1030,17 @@ add_notification_action(GtkWindow *nw, const char *text, const char *key,
 	gtk_label_set_markup(GTK_LABEL(label), buf);
 	g_free(buf);
 
+add_button:
+	gtk_widget_show(button);
+	gtk_box_pack_start(GTK_BOX(windata->actions_box), button, FALSE, FALSE, 0);
+
 	g_object_set_data(G_OBJECT(button), "_nw", nw);
 	g_object_set_data_full(G_OBJECT(button),
 						   "_action_key", g_strdup(key), g_free);
 	g_signal_connect(G_OBJECT(button), "button-release-event",
 					 G_CALLBACK(action_clicked_cb), cb);
+
+	gtk_widget_show_all(windata->actions_box);
 }
 
 /* Clear notification actions */

--- a/src/themes/slider/theme.c
+++ b/src/themes/slider/theme.c
@@ -732,11 +732,13 @@ void add_notification_action(GtkWindow* nw, const char* text, const char* key, A
 		}
 	}
 
+	if (windata->action_icons) {
+		button = gtk_button_new_from_icon_name(key, GTK_ICON_SIZE_BUTTON);
+		goto add_button;
+	}
+
 	button = gtk_button_new();
 	gtk_widget_show(button);
-	gtk_box_pack_start(GTK_BOX(windata->actions_box), button, FALSE, FALSE, 0);
-	gtk_button_set_relief(GTK_BUTTON(button), GTK_RELIEF_NONE);
-	gtk_container_set_border_width(GTK_CONTAINER(button), 0);
 
 	hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 6);
 	gtk_widget_show(hbox);
@@ -770,9 +772,16 @@ void add_notification_action(GtkWindow* nw, const char* text, const char* key, A
 	gtk_label_set_markup(GTK_LABEL(label), buf);
 	g_free(buf);
 
+add_button:
+	gtk_box_pack_start(GTK_BOX(windata->actions_box), button, FALSE, FALSE, 0);
+	gtk_button_set_relief(GTK_BUTTON(button), GTK_RELIEF_NONE);
+	gtk_container_set_border_width(GTK_CONTAINER(button), 0);
+
 	g_object_set_data(G_OBJECT(button), "_nw", nw);
 	g_object_set_data_full(G_OBJECT(button), "_action_key", g_strdup(key), g_free);
 	g_signal_connect(G_OBJECT(button), "button-release-event", G_CALLBACK(on_action_clicked), cb);
+
+	gtk_widget_show_all(windata->actions_box);
 }
 
 void clear_notification_actions(GtkWindow* nw)

--- a/src/themes/slider/theme.c
+++ b/src/themes/slider/theme.c
@@ -42,6 +42,7 @@ typedef struct {
 
 	gboolean has_arrow;
 	gboolean composited;
+	gboolean action_icons;
 
 	int width;
 	int height;
@@ -450,26 +451,31 @@ GtkWindow* create_notification(UrlClickedCb url_clicked)
 	return GTK_WINDOW(win);
 }
 
-void set_notification_hints(GtkWindow* nw, GHashTable* hints)
+void set_notification_hints(GtkWindow *nw, GHashTable *hints)
 {
-	WindowData* windata = g_object_get_data(G_OBJECT(nw), "windata");
+	WindowData *windata = g_object_get_data(G_OBJECT(nw), "windata");
+	GValue *value = NULL, *icon_value = NULL;
 
 	g_assert(windata != NULL);
 
-	GValue* value = (GValue*) g_hash_table_lookup(hints, "urgency");
+	value = (GValue *)g_hash_table_lookup(hints, "urgency");
+	icon_value = (GValue *)g_hash_table_lookup(hints, "action-icons");
 
 	if (value != NULL && G_VALUE_HOLDS_UCHAR(value))
 	{
 		windata->urgency = g_value_get_uchar(value);
 
-		if (windata->urgency == URGENCY_CRITICAL)
-		{
+		if (windata->urgency == URGENCY_CRITICAL) {
 			gtk_window_set_title(GTK_WINDOW(nw), "Critical Notification");
-		}
-		else
-		{
+		} else {
 			gtk_window_set_title(GTK_WINDOW(nw), "Notification");
 		}
+	}
+
+	/* Determine if action-icons have been requested */
+	if (icon_value != NULL && G_VALUE_HOLDS_BOOLEAN(icon_value))
+	{
+		windata->action_icons = g_value_get_boolean(icon_value);
 	}
 }
 

--- a/src/themes/slider/theme.c
+++ b/src/themes/slider/theme.c
@@ -722,6 +722,7 @@ void add_notification_action(GtkWindow* nw, const char* text, const char* key, A
 		if (!windata->pie_countdown) {
 			windata->pie_countdown = gtk_drawing_area_new();
 			gtk_widget_set_halign (windata->pie_countdown, GTK_ALIGN_END);
+			gtk_widget_set_valign (windata->pie_countdown, GTK_ALIGN_CENTER);
 			gtk_widget_show(windata->pie_countdown);
 
 			gtk_box_pack_end (GTK_BOX (windata->actions_box), windata->pie_countdown, FALSE, TRUE, 0);

--- a/src/themes/slider/theme.c
+++ b/src/themes/slider/theme.c
@@ -718,14 +718,18 @@ void add_notification_action(GtkWindow* nw, const char* text, const char* key, A
 		gtk_widget_show(windata->actions_box);
 		update_content_hbox_visibility(windata);
 
-		windata->pie_countdown = gtk_drawing_area_new();
+		/* Don't try to re-add a pie_countdown */
+		if (!windata->pie_countdown) {
+			windata->pie_countdown = gtk_drawing_area_new();
+			gtk_widget_set_halign (windata->pie_countdown, GTK_ALIGN_END);
+			gtk_widget_show(windata->pie_countdown);
 
-		gtk_widget_set_halign (windata->pie_countdown, GTK_ALIGN_END);
-		gtk_widget_show(windata->pie_countdown);
-
-		gtk_box_pack_end (GTK_BOX (windata->actions_box), windata->pie_countdown, FALSE, TRUE, 0);
-		gtk_widget_set_size_request(windata->pie_countdown, PIE_WIDTH, PIE_HEIGHT);
-		g_signal_connect(G_OBJECT(windata->pie_countdown), "draw", G_CALLBACK(on_countdown_draw), windata);
+			gtk_box_pack_end (GTK_BOX (windata->actions_box), windata->pie_countdown, FALSE, TRUE, 0);
+			gtk_widget_set_size_request(windata->pie_countdown,
+						    PIE_WIDTH, PIE_HEIGHT);
+			g_signal_connect(G_OBJECT(windata->pie_countdown), "draw",
+					 G_CALLBACK(on_countdown_draw), windata);
+		}
 	}
 
 	button = gtk_button_new();

--- a/src/themes/standard/theme.c
+++ b/src/themes/standard/theme.c
@@ -1036,10 +1036,12 @@ void add_notification_action(GtkWindow* nw, const char* text, const char* key, A
 		}
 	}
 
-	button = gtk_button_new();
-	gtk_widget_show(button);
-	gtk_box_pack_start(GTK_BOX(windata->actions_box), button, FALSE, FALSE, 0);
+	if (windata->action_icons) {
+		button = gtk_button_new_from_icon_name(key, GTK_ICON_SIZE_BUTTON);
+		goto add_button;
+	}
 
+	button = gtk_button_new();
 	hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 6);
 	gtk_widget_show(hbox);
 	gtk_container_add(GTK_CONTAINER(button), hbox);
@@ -1072,9 +1074,15 @@ void add_notification_action(GtkWindow* nw, const char* text, const char* key, A
 	gtk_label_set_markup(GTK_LABEL(label), buf);
 	g_free(buf);
 
+add_button:
+	gtk_widget_show(button);
+	gtk_box_pack_start(GTK_BOX(windata->actions_box), button, FALSE, FALSE, 0);
+
 	g_object_set_data(G_OBJECT(button), "_nw", nw);
 	g_object_set_data_full(G_OBJECT(button), "_action_key", g_strdup(key), g_free);
 	g_signal_connect(G_OBJECT(button), "button-release-event", G_CALLBACK(action_clicked_cb), cb);
+
+	gtk_widget_show_all(windata->actions_box);
 }
 
 void clear_notification_actions(GtkWindow* nw)

--- a/src/themes/standard/theme.c
+++ b/src/themes/standard/theme.c
@@ -1022,12 +1022,18 @@ void add_notification_action(GtkWindow* nw, const char* text, const char* key, A
 		gtk_widget_show(windata->actions_box);
 		update_content_hbox_visibility(windata);
 
-		windata->pie_countdown = gtk_drawing_area_new();
-		gtk_widget_set_halign (windata->pie_countdown, GTK_ALIGN_END);
-		gtk_widget_show(windata->pie_countdown);
-		gtk_box_pack_end(GTK_BOX(windata->actions_box), windata->pie_countdown, FALSE, TRUE, 0);
-		gtk_widget_set_size_request(windata->pie_countdown, PIE_WIDTH, PIE_HEIGHT);
-		g_signal_connect (G_OBJECT (windata->pie_countdown), "draw", G_CALLBACK (on_countdown_draw), windata);
+		/* Don't try to re-add a pie_countdown */
+		if (!windata->pie_countdown) {
+			windata->pie_countdown = gtk_drawing_area_new();
+			gtk_widget_set_halign (windata->pie_countdown, GTK_ALIGN_END);
+			gtk_widget_show(windata->pie_countdown);
+
+			gtk_box_pack_end (GTK_BOX (windata->actions_box), windata->pie_countdown, FALSE, TRUE, 0);
+			gtk_widget_set_size_request(windata->pie_countdown,
+						    PIE_WIDTH, PIE_HEIGHT);
+			g_signal_connect(G_OBJECT(windata->pie_countdown), "draw",
+					 G_CALLBACK(on_countdown_draw), windata);
+		}
 	}
 
 	button = gtk_button_new();

--- a/src/themes/standard/theme.c
+++ b/src/themes/standard/theme.c
@@ -45,6 +45,7 @@ typedef struct {
 
 	gboolean has_arrow;
 	gboolean composited;
+	gboolean action_icons;
 
 	int point_x;
 	int point_y;
@@ -796,26 +797,31 @@ GtkWindow* create_notification(UrlClickedCb url_clicked)
 	return GTK_WINDOW(win);
 }
 
-void set_notification_hints(GtkWindow* nw, GHashTable* hints)
+void set_notification_hints(GtkWindow *nw, GHashTable *hints)
 {
-	WindowData* windata = g_object_get_data(G_OBJECT(nw), "windata");
+	WindowData *windata = g_object_get_data(G_OBJECT(nw), "windata");
+	GValue *value = NULL, *icon_value = NULL;
 
 	g_assert(windata != NULL);
 
-	GValue* value = (GValue*) g_hash_table_lookup(hints, "urgency");
+	value = (GValue *)g_hash_table_lookup(hints, "urgency");
+	icon_value = (GValue *)g_hash_table_lookup(hints, "action-icons");
 
 	if (value != NULL && G_VALUE_HOLDS_UCHAR(value))
 	{
 		windata->urgency = g_value_get_uchar(value);
 
-		if (windata->urgency == URGENCY_CRITICAL)
-		{
+		if (windata->urgency == URGENCY_CRITICAL) {
 			gtk_window_set_title(GTK_WINDOW(nw), "Critical Notification");
-		}
-		else
-		{
+		} else {
 			gtk_window_set_title(GTK_WINDOW(nw), "Notification");
 		}
+	}
+
+	/* Determine if action-icons have been requested */
+	if (icon_value != NULL && G_VALUE_HOLDS_BOOLEAN(icon_value))
+	{
+		windata->action_icons = g_value_get_boolean(icon_value);
 	}
 }
 


### PR DESCRIPTION
This PR adds support to MATE Notification Daemon for the `action-icons` attribute, per capabilites + hints in the freedesktop Notifications Specification. These permit icons to be used in place of labels, with self describing icons (see 7aeebb6 in this PR for a full explanation)

It also exposed a number of bugs, subsequently fixed, in the existing themes when updating a live notification. The existing textual actions would disappear (`gtk+-3.0 3.20`) once a live notification is updated, for example by Rhythmbox. 

It also turns out that pie_countdown's were duplicated or borky in one respect or another.

As this now returns functionality which has been missing for a while, it also exposed `Coco` buttons being quite ugly, and the pie_countdown in `Slider` having a black background. I feel these are out of scope for this pull request, and the visual styling for these elements, now correctly working, should be asserted by the MATE Desktop team, and not myself. The only recommendation I would make is that with the `Slider` theme, the `actions_box` align with the center horizontally when using `action_icons`, and retain `end` alignment when using textual actions.

The Solus [MATE Notification Theme](https://github.com/solus-project/mate-notification-theme-solus):

![screenshot at 2016-11-16 19-00-24](https://cloud.githubusercontent.com/assets/164489/20372636/ab3c354e-ac64-11e6-89d8-ee282e5373d6.png)


`Nodoka` theme (part of core MATE Notification Daemon themes):

![screenshot at 2016-11-16 18-43-53](https://cloud.githubusercontent.com/assets/164489/20372638/b335f190-ac64-11e6-800d-0c9329bd5b81.png)
