### PR TITLE
avoid deprecated gdk_screen_get_n_monitors

### DIFF
--- a/src/capplet/mate-notification-properties.c
+++ b/src/capplet/mate-notification-properties.c
@@ -213,7 +213,11 @@ static void notification_properties_dialog_setup_monitors(NotificationAppletDial
 	screen = gdk_display_get_default_screen(display);
 	g_assert(screen != NULL);
 	
+#if GTK_CHECK_VERSION (3, 22, 0)
+	num_monitors = gdk_display_get_n_monitors(display);
+#else
 	num_monitors = gdk_screen_get_n_monitors(screen);
+#endif
 	g_assert(num_monitors >= 1);
 	
 	store = gtk_list_store_new(N_COLUMNS_MONITOR, G_TYPE_INT);

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -185,13 +185,21 @@ static void create_stack_for_monitor(NotifyDaemon* daemon, GdkScreen* screen, in
 
 static void on_screen_monitors_changed(GdkScreen* screen, NotifyDaemon* daemon)
 {
+#if GTK_CHECK_VERSION (3, 22, 0)
+	GdkDisplay     *display;
+#endif
 	NotifyScreen* nscreen;
 	int n_monitors;
 	int i;
 
 	nscreen = daemon->priv->screen;
+#if GTK_CHECK_VERSION (3, 22, 0)
+	display = gdk_screen_get_display (screen);
 
+	n_monitors = gdk_display_get_n_monitors(display);
+#else
 	n_monitors = gdk_screen_get_n_monitors(screen);
+#endif
 
 	if (n_monitors > nscreen->n_stacks)
 	{
@@ -240,12 +248,20 @@ static void on_screen_monitors_changed(GdkScreen* screen, NotifyDaemon* daemon)
 
 static void create_stacks_for_screen(NotifyDaemon* daemon, GdkScreen *screen)
 {
+#if GTK_CHECK_VERSION (3, 22, 0)
+	GdkDisplay     *display;
+#endif
 	NotifyScreen* nscreen;
 	int i;
 
 	nscreen = daemon->priv->screen;
+#if GTK_CHECK_VERSION (3, 22, 0)
+	display = gdk_screen_get_display (screen);
 
+	nscreen->n_stacks = gdk_display_get_n_monitors(display);
+#else
 	nscreen->n_stacks = gdk_screen_get_n_monitors(screen);
+#endif
 
 	nscreen->stacks = g_renew(NotifyStack*, nscreen->stacks, nscreen->n_stacks);
 

--- a/src/daemon/stack.c
+++ b/src/daemon/stack.c
@@ -196,10 +196,18 @@ notify_stack_new (NotifyDaemon       *daemon,
                   NotifyStackLocation location)
 {
         NotifyStack    *stack;
+#if GTK_CHECK_VERSION (3, 22, 0)
+        GdkDisplay     *display;
 
+        display = gdk_screen_get_display (screen);
+#endif
         g_assert (daemon != NULL);
         g_assert (screen != NULL && GDK_IS_SCREEN (screen));
+#if GTK_CHECK_VERSION (3, 22, 0)
+        g_assert (monitor < (guint)gdk_display_get_n_monitors (display));
+#else
         g_assert (monitor < (guint)gdk_screen_get_n_monitors (screen));
+#endif
         g_assert (location != NOTIFY_STACK_LOCATION_UNKNOWN);
 
         stack = g_new0 (NotifyStack, 1);


### PR DESCRIPTION
Use `gdk_display_get_n_monitors` instead

since gtk 3.22