### PR TITLE
WidthOfScreen and HeightOfScreen implementation

### DIFF
--- a/src/daemon/stack.c
+++ b/src/daemon/stack.c
@@ -75,9 +75,8 @@ get_work_area (NotifyStack  *stack,
         /* Defaults in case of error */
         rect->x = 0;
         rect->y = 0;
-
-        gdk_window_get_geometry (gdk_screen_get_root_window (stack->screen), NULL, NULL,
-                                 &rect->width, &rect->height);
+        rect->width = WidthOfScreen (gdk_x11_screen_get_xscreen (stack->screen));
+        rect->height = HeightOfScreen (gdk_x11_screen_get_xscreen (stack->screen));
 
         if (workarea == None)
                 return FALSE;

--- a/src/themes/nodoka/nodoka-theme.c
+++ b/src/themes/nodoka/nodoka-theme.c
@@ -27,6 +27,7 @@
 
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
+#include <gdk/gdkx.h>
 
 /* Define basic nodoka types */
 typedef void (*ActionInvokedCb)(GtkWindow *nw, const char *key);
@@ -137,8 +138,8 @@ get_notification_arrow_type(GtkWidget *nw)
 	WindowData *windata = g_object_get_data(G_OBJECT(nw), "windata");
 	int screen_height;
 
-	gdk_window_get_geometry (gdk_screen_get_root_window (gdk_window_get_screen (gtk_widget_get_window (nw))),
-				 NULL, NULL, NULL, &screen_height);
+	screen_height = HeightOfScreen (gdk_x11_screen_get_xscreen (
+		gdk_window_get_screen (gtk_widget_get_window (nw))));
 
 	if (windata->arrow.position.y + windata->height + DEFAULT_ARROW_HEIGHT >
 		screen_height)
@@ -159,8 +160,8 @@ set_arrow_parameters (WindowData *windata)
 	int x,y;
 	GtkArrowType arrow_type;
 
-	gdk_window_get_geometry (gdk_screen_get_root_window (gdk_window_get_screen (gtk_widget_get_window (windata->win))),
-				 NULL, NULL, &screen_width, NULL);
+	screen_width = WidthOfScreen (gdk_x11_screen_get_xscreen (
+		gdk_window_get_screen (gtk_widget_get_window (windata->win))));
 
 	/* Set arrow offset */
 	GtkAllocation alloc;


### PR DESCRIPTION
This commit reverts:

https://github.com/mate-desktop/mate-notification-daemon/commit/52b7c3807e71278f2d902a79cf6c08c839a1b0ad

And it applies an alternative to fix the deprecated functions:

gdk_screen_get_width
gdk_screen_get_height