### PR TITLE
Add do-not-disturb setting

### DIFF
--- a/data/org.mate.NotificationDaemon.gschema.xml.in
+++ b/data/org.mate.NotificationDaemon.gschema.xml.in
@@ -25,5 +25,10 @@
       <summary>Sound Enabled</summary>
       <description>Turns on and off sound support for notifications.</description>
     </key>
+    <key name="do-not-disturb" type="b">
+      <default>false</default>
+      <summary>Do not disturb</summary>
+      <description>When enabled, notifications are not shown.</description>
+    </key>
   </schema>
 </schemalist>

--- a/src/capplet/mate-notification-properties.c
+++ b/src/capplet/mate-notification-properties.c
@@ -612,6 +612,8 @@ static gboolean notification_properties_dialog_init(NotificationAppletDialog* di
         gtk_widget_set_sensitive(dialog->monitor_label, TRUE);
 	}
 
+	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON (dialog->dnd_checkbox), g_settings_get_boolean(dialog->gsettings, GSETTINGS_KEY_DO_NOT_DISTURB));
+
 	gtk_widget_show_all(dialog->dialog);
 
 	dialog->preview = NULL;

--- a/src/capplet/mate-notification-properties.ui
+++ b/src/capplet/mate-notification-properties.ui
@@ -127,7 +127,7 @@
                   <object class="GtkTable" id="table3">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="n_rows">4</property>
+                    <property name="n_rows">5</property>
                     <property name="n_columns">2</property>
                     <property name="column_spacing">12</property>
                     <property name="row_spacing">6</property>
@@ -246,6 +246,22 @@
                         <property name="right_attach">2</property>
                         <property name="top_attach">3</property>
                         <property name="bottom_attach">4</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkCheckButton" id="do_not_disturb_check">
+                        <property name="label" translatable="yes">Enable Do Not Disturb</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="use_action_appearance">False</property>
+                        <property name="active">True</property>
+                        <property name="draw_indicator">True</property>
+                      </object>
+                      <packing>
+                        <property name="right_attach">2</property>
+                        <property name="top_attach">4</property>
+                        <property name="bottom_attach">5</property>
                       </packing>
                     </child>
                   </object>

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -1338,7 +1338,6 @@ static gboolean notify_daemon_notify_handler(NotifyDaemonNotifications *object, 
 	/* If we are in do-not-disturb mode, just grab a new id and close the notification */
 	if (do_not_disturb)
 	{
-		/* FIXME: does this break things if we enable the option with an action notification up */
 		return_id = _generate_id (daemon);
 		notify_daemon_notifications_complete_notify (object, invocation, return_id);
 		return TRUE;

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -32,6 +32,7 @@
 #define GSETTINGS_KEY_THEME          "theme"
 #define GSETTINGS_KEY_POPUP_LOCATION "popup-location"
 #define GSETTINGS_KEY_SOUND_ENABLED  "sound-enabled"
+#define GSETTINGS_KEY_DO_NOT_DISTURB "do-not-disturb"
 #define GSETTINGS_KEY_MONITOR_NUMBER "monitor-number"
 #define GSETTINGS_KEY_USE_ACTIVE     "use-active-monitor"
 


### PR DESCRIPTION
Adds a do-not-disturb gsettings boolean key, an "Enable Do Not Disturb" checkbox to mate-notification-properties, and silently discards notifications when the key is set by generating a new return_id and immediately closing the notification.