### PR TITLE
[1.22] build: drop MATE_CXX_WARNINGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -179,7 +179,6 @@ dnl ---------------------------------------------------------------------------
 dnl Turn on the additional warnings last
 dnl ---------------------------------------------------------------------------
 MATE_COMPILE_WARNINGS([maximum])
-MATE_CXX_WARNINGS([yes])
 MATE_MAINTAINER_MODE_DEFINES
 
 AC_ARG_ENABLE(more-warnings,


### PR DESCRIPTION
Fixes debian build