### PR TITLE
Remove conversion warnings

### DIFF
--- a/src/daemon/engines.c
+++ b/src/daemon/engines.c
@@ -50,7 +50,7 @@ typedef struct {
 
 } ThemeEngine;
 
-static guint        theme_prop_notify_id = 0;
+static gulong       theme_prop_notify_id = 0;
 static ThemeEngine* active_engine = NULL;
 
 static ThemeEngine* load_theme_engine(const char *name)

--- a/src/daemon/stack.c
+++ b/src/daemon/stack.c
@@ -57,7 +57,7 @@ get_work_area (NotifyStack  *stack,
         int             format;
         gulong          num;
         gulong          leftovers;
-        gulong          max_len = 4 * 32;
+        long            max_len = 4 * 32;
         guchar         *ret_workarea;
         long           *workareas;
         int             result;
@@ -103,10 +103,10 @@ get_work_area (NotifyStack  *stack,
         }
 
         workareas = (long *) ret_workarea;
-        rect->x = workareas[disp_screen * 4];
-        rect->y = workareas[disp_screen * 4 + 1];
-        rect->width = workareas[disp_screen * 4 + 2];
-        rect->height = workareas[disp_screen * 4 + 3];
+        rect->x = (int) workareas[disp_screen * 4];
+        rect->y = (int) workareas[disp_screen * 4 + 1];
+        rect->width = (int) workareas[disp_screen * 4 + 2];
+        rect->height = (int) workareas[disp_screen * 4 + 3];
 
         XFree (ret_workarea);
 
@@ -287,8 +287,8 @@ notify_stack_shift_notifications (NotifyStack *stack,
         gint            x, y;
         gint            shiftx = 0;
         gint            shifty = 0;
-        int             i;
-        int             n_wins;
+        guint           i;
+        guint           n_wins;
 
         get_work_area (stack, &workarea);
         gdk_monitor_get_geometry (stack->monitor, &monitor);

--- a/src/themes/coco/coco-theme.c
+++ b/src/themes/coco/coco-theme.c
@@ -103,7 +103,7 @@ void notification_tick(GtkWindow *nw, glong remaining);
 #define DEFAULT_ARROW_HEIGHT  14
 #define DEFAULT_ARROW_WIDTH   22
 #define DEFAULT_ARROW_SKEW    -6
-#define BACKGROUND_OPACITY    0.90
+#define BACKGROUND_OPACITY    0.9
 #define GRADIENT_CENTER 0.7
 
 /* Support Nodoka Functions */
@@ -140,7 +140,7 @@ nodoka_rounded_rectangle (cairo_t * cr,
 static void
 fill_background(GtkWidget *widget, WindowData *windata, cairo_t *cr)
 {
-	float alpha;
+	double alpha;
 	if (windata->composited)
 		alpha = BACKGROUND_OPACITY;
 	else
@@ -490,6 +490,7 @@ void
 set_notification_text(GtkWindow *nw, const char *summary, const char *body)
 {
 	char *str;
+	size_t str_len;
 	char *quoted;
 	WindowData *windata = g_object_get_data(G_OBJECT(nw), "windata");
 	g_assert(windata != NULL);
@@ -507,7 +508,8 @@ set_notification_text(GtkWindow *nw, const char *summary, const char *body)
 	xmlInitParser();
 	str = g_strconcat ("<markup>", "<span color=\"#EAEAEA\">", body, "</span>", "</markup>", NULL);
 	/* parse notification body */
-	doc = xmlReadMemory(str, strlen (str), "noname.xml", NULL, 0);
+	str_len = strlen (str);
+	doc = xmlReadMemory(str, (int) str_len, "noname.xml", NULL, 0);
 	g_free (str);
 	if (doc != NULL) {
 		xmlXPathContextPtr xpathCtx;

--- a/src/themes/nodoka/nodoka-theme.c
+++ b/src/themes/nodoka/nodoka-theme.c
@@ -322,12 +322,12 @@ nodoka_rounded_rectangle_with_arrow (cairo_t * cr,
 
 	cairo_rectangle_int_t rect;
 	rect.x = 0;
-	rect.width = w;
+	rect.width = (int)w;
 	if (arrow_up)
 		rect.y = 0 + DEFAULT_ARROW_HEIGHT;
 	else
 		rect.y = 0;
-	rect.height = h - DEFAULT_ARROW_HEIGHT;
+	rect.height = (int)(h - DEFAULT_ARROW_HEIGHT);
 
 	cairo_move_to (cr, rect.x + radius, rect.y);
 
@@ -369,7 +369,7 @@ nodoka_rounded_rectangle_with_arrow (cairo_t * cr,
 static void
 fill_background(GtkWidget *widget, WindowData *windata, cairo_t *cr)
 {
-	float alpha;
+	double alpha;
 	if (windata->composited)
 		alpha = BACKGROUND_OPACITY;
 	else
@@ -405,7 +405,7 @@ draw_stripe(GtkWidget *widget, WindowData *windata, cairo_t *cr)
 	GdkRGBA  center_color;
 	GdkRGBA  bottom_color;
 
-	float alpha;
+	double alpha;
 	if (windata->composited)
 		alpha = BACKGROUND_OPACITY;
 	else
@@ -475,7 +475,7 @@ draw_stripe(GtkWidget *widget, WindowData *windata, cairo_t *cr)
 static void
 draw_border(GtkWidget *widget, WindowData *windata, cairo_t *cr)
 {
-	float alpha;
+	double alpha;
 	if (windata->composited)
 		alpha = BACKGROUND_OPACITY;
 	else
@@ -876,6 +876,7 @@ void
 set_notification_text(GtkWindow *nw, const char *summary, const char *body)
 {
 	char *str;
+	size_t str_len;
 	char* quoted;
 	WindowData *windata = g_object_get_data(G_OBJECT(nw), "windata");
 	g_assert(windata != NULL);
@@ -892,7 +893,8 @@ set_notification_text(GtkWindow *nw, const char *summary, const char *body)
 	xmlInitParser();
 	str = g_strconcat ("<markup>", "<span color=\"#000000\">", body, "</span>", "</markup>", NULL);
 	/* parse notification body */
-	doc = xmlReadMemory(str, strlen (str), "noname.xml", NULL, 0);
+	str_len = strlen (str);
+	doc = xmlReadMemory(str, (int) str_len, "noname.xml", NULL, 0);
 	g_free (str);
 	if (doc != NULL) {
 		xmlXPathContextPtr xpathCtx;

--- a/src/themes/slider/theme.c
+++ b/src/themes/slider/theme.c
@@ -495,6 +495,7 @@ void notification_tick(GtkWindow* nw, glong remaining)
 void set_notification_text(GtkWindow* nw, const char* summary, const char* body)
 {
 	char* str;
+	size_t str_len;
 	char* quoted;
 	GtkRequisition req;
 	WindowData* windata;
@@ -516,7 +517,8 @@ void set_notification_text(GtkWindow* nw, const char* summary, const char* body)
 	xmlInitParser();
 	str = g_strconcat ("<markup>", body, "</markup>", NULL);
 	/* parse notification body */
-	doc = xmlReadMemory(str, strlen (str), "noname.xml", NULL, 0);
+	str_len = strlen (str);
+	doc = xmlReadMemory(str, (int) str_len, "noname.xml", NULL, 0);
 	g_free (str);
 	if (doc != NULL) {
 		xmlXPathContextPtr xpathCtx;
@@ -613,8 +615,8 @@ static GdkPixbuf* scale_pixbuf(GdkPixbuf* pixbuf, int max_width, int max_height,
 		int scale_x;
 		int scale_y;
 
-		scale_x = (int) (pw * scale_factor);
-		scale_y = (int) (ph * scale_factor);
+		scale_x = (int) (((float) pw) * scale_factor);
+		scale_y = (int) (((float) ph) * scale_factor);
 
 		return gdk_pixbuf_scale_simple(pixbuf, scale_x, scale_y, GDK_INTERP_BILINEAR);
 	}

--- a/src/themes/standard/theme.c
+++ b/src/themes/standard/theme.c
@@ -845,6 +845,7 @@ void notification_tick(GtkWindow* nw, glong remaining)
 void set_notification_text(GtkWindow* nw, const char* summary, const char* body)
 {
 	char* str;
+	size_t str_len;
 	char* quoted;
 	GtkRequisition req;
 	WindowData* windata;
@@ -864,7 +865,8 @@ void set_notification_text(GtkWindow* nw, const char* summary, const char* body)
 	xmlInitParser();
 	str = g_strconcat ("<markup>", body, "</markup>", NULL);
 	/* parse notification body */
-	doc = xmlReadMemory(str, strlen (str), "noname.xml", NULL, 0);
+	str_len = strlen (str);
+	doc = xmlReadMemory(str, (int) str_len, "noname.xml", NULL, 0);
 	g_free (str);
 	if (doc != NULL) {
 		xmlXPathContextPtr xpathCtx;


### PR DESCRIPTION
```
$ CFLAGS="-Wconversion" ./autogen.sh  --enable-compile-warnings=maximum --prefix=/usr && make &> make.log && sudo make install
$ grep -A 2 conversion make.log
daemon.c:939:24: warning: conversion to ‘gsize’ {aka ‘long unsigned int’} from ‘int’ may change the sign of the result [-Wsign-conversion]
  939 |         expected_len = (height - 1) * rowstride + width
      |                        ^
daemon.c:951:37: warning: conversion from ‘gsize’ {aka ‘long unsigned int’} to ‘guint’ {aka ‘unsigned int’} may change value [-Wconversion]
  951 |                                     g_variant_get_size (data_variant));
      |                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
--
daemon.c:1036:23: warning: conversion from ‘int’ to ‘float’ may change value [-Wconversion]
 1036 |   scale_x = (int) (pw * scale_factor);
      |                       ^
daemon.c:1037:23: warning: conversion from ‘int’ to ‘float’ may change value [-Wconversion]
 1037 |   scale_y = (int) (ph * scale_factor);
      |                       ^
--
daemon.c:1274:4: warning: conversion to ‘unsigned int’ from ‘int’ may change the sign of the result [-Wsign-conversion]
 1274 |  x += width / 2;
      |    ^~
daemon.c:1274:7: warning: conversion to ‘int’ from ‘unsigned int’ may change the sign of the result [-Wsign-conversion]
 1274 |  x += width / 2;
      |       ^~~~~
daemon.c:1275:4: warning: conversion to ‘unsigned int’ from ‘int’ may change the sign of the result [-Wsign-conversion]
 1275 |  y += height / 2;
      |    ^~
daemon.c:1275:7: warning: conversion to ‘int’ from ‘unsigned int’ may change the sign of the result [-Wsign-conversion]
 1275 |  y += height / 2;
      |       ^~~~~~
--
/usr/include/glib-2.0/gobject/gsignal.h:491:5: warning: conversion from ‘gulong’ {aka ‘long unsigned int’} to ‘guint’ {aka ‘unsigned int’} may change value [-Wconversion]
  491 |     g_signal_connect_data ((instance), (detailed_signal), (c_handler), (data), NULL, (GConnectFlags) 0)
      |     ^~~~~~~~~~~~~~~~~~~~~
--
stack.c:87:3: warning: conversion to ‘long int’ from ‘gulong’ {aka ‘long unsigned int’} may change the sign of the result [-Wsign-conversion]
   87 |   max_len,
      |   ^~~~~~~
stack.c:106:19: warning: conversion from ‘long int’ to ‘int’ may change value [-Wconversion]
  106 |         rect->x = workareas[disp_screen * 4];
      |                   ^~~~~~~~~
stack.c:107:19: warning: conversion from ‘long int’ to ‘int’ may change value [-Wconversion]
  107 |         rect->y = workareas[disp_screen * 4 + 1];
      |                   ^~~~~~~~~
stack.c:108:23: warning: conversion from ‘long int’ to ‘int’ may change value [-Wconversion]
  108 |         rect->width = workareas[disp_screen * 4 + 2];
      |                       ^~~~~~~~~
stack.c:109:24: warning: conversion from ‘long int’ to ‘int’ may change value [-Wconversion]
  109 |         rect->height = workareas[disp_screen * 4 + 3];
      |                        ^~~~~~~~~
--
stack.c:299:18: warning: conversion to ‘int’ from ‘guint’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
  299 |         n_wins = g_list_length (stack->windows);
      |                  ^~~~~~~~~~~~~
--
coco-theme.c:106:31: warning: conversion from ‘double’ to ‘float’ changes value from ‘9.0000000000000002e-1’ to ‘8.99999976e-1f’ [-Wfloat-conversion]
  106 | #define BACKGROUND_OPACITY    0.90
      |                               ^~~~
--
coco-theme.c:510:27: warning: conversion from ‘size_t’ {aka ‘long unsigned int’} to ‘int’ may change value [-Wconversion]
  510 |  doc = xmlReadMemory(str, strlen (str), "noname.xml", NULL, 0);
      |                           ^~~~~~~~~~~~
--
nodoka-theme.c:325:15: warning: conversion from ‘double’ to ‘int’ may change value [-Wfloat-conversion]
  325 |  rect.width = w;
      |               ^
nodoka-theme.c:330:16: warning: conversion from ‘double’ to ‘int’ may change value [-Wfloat-conversion]
  330 |  rect.height = h - DEFAULT_ARROW_HEIGHT;
      |                ^
--
nodoka-theme.c:123:31: warning: conversion from ‘double’ to ‘float’ changes value from ‘9.2000000000000004e-1’ to ‘9.20000017e-1f’ [-Wfloat-conversion]
  123 | #define BACKGROUND_OPACITY    0.92
      |                               ^~~~
--
nodoka-theme.c:123:31: warning: conversion from ‘double’ to ‘float’ changes value from ‘9.2000000000000004e-1’ to ‘9.20000017e-1f’ [-Wfloat-conversion]
  123 | #define BACKGROUND_OPACITY    0.92
      |                               ^~~~
--
nodoka-theme.c:417:12: warning: conversion from ‘double’ to ‘float’ may change value [-Wfloat-conversion]
  417 |    alpha = alpha * 0.5;
      |            ^~~~~
--
nodoka-theme.c:123:31: warning: conversion from ‘double’ to ‘float’ changes value from ‘9.2000000000000004e-1’ to ‘9.20000017e-1f’ [-Wfloat-conversion]
  123 | #define BACKGROUND_OPACITY    0.92
      |                               ^~~~
--
nodoka-theme.c:895:27: warning: conversion from ‘size_t’ {aka ‘long unsigned int’} to ‘int’ may change value [-Wconversion]
  895 |  doc = xmlReadMemory(str, strlen (str), "noname.xml", NULL, 0);
      |                           ^~~~~~~~~~~~
--
theme.c:519:27: warning: conversion from ‘size_t’ {aka ‘long unsigned int’} to ‘int’ may change value [-Wconversion]
  519 |  doc = xmlReadMemory(str, strlen (str), "noname.xml", NULL, 0);
      |                           ^~~~~~~~~~~~
--
theme.c:616:23: warning: conversion from ‘int’ to ‘float’ may change value [-Wconversion]
  616 |   scale_x = (int) (pw * scale_factor);
      |                       ^
theme.c:617:23: warning: conversion from ‘int’ to ‘float’ may change value [-Wconversion]
  617 |   scale_y = (int) (ph * scale_factor);
      |                       ^
--
theme.c:867:27: warning: conversion from ‘size_t’ {aka ‘long unsigned int’} to ‘int’ may change value [-Wconversion]
  867 |  doc = xmlReadMemory(str, strlen (str), "noname.xml", NULL, 0);
      |                           ^~~~~~~~~~~~
```