### PR TITLE
Wayland support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -183,7 +183,6 @@ if test "x$enable_x11" != "xno"; then
 fi
 
 AM_CONDITIONAL(ENABLE_WAYLAND, [test "x$have_wayland" = "xyes"])
-AM_CONDITIONAL(ENABLE_X11, [test "x$have_x11" = "xyes"])
 
 if test "x$have_x11" != "xyes" -a "x$have_wayland" != "xyes"; then
   AC_MSG_ERROR([At least one backend must be enabled (--enable-x11 or --enable-wayland)])

--- a/configure.ac
+++ b/configure.ac
@@ -126,11 +126,70 @@ pkg_modules="
 	glib-2.0 >= $REQ_GLIB_VERSION, \
 	gio-2.0 >= $REQ_GLIB_VERSION, \
         $GMODULE_ADD \
-        libcanberra-gtk3 >= $REQ_LIBCANBERRA_GTK_VERSION, \
-	libwnck-3.0 \
-        x11 \
+        libcanberra-gtk3 >= $REQ_LIBCANBERRA_GTK_VERSION \
 "
 PKG_CHECK_MODULES(NOTIFICATION_DAEMON, $pkg_modules)
+
+dnl Will call AC_SUBSET on NOTIFICATION_DAEMON_* below after appending X11 and Wayland flags
+
+dnl ---------------------------------------------------------------------------
+dnl Support X11, Wayland or both for the daemon
+dnl ---------------------------------------------------------------------------
+
+dnl $enable_x11 and $enable_wayland will be set to "yes", "no" or "auto"
+AC_ARG_ENABLE(x11,
+	[AC_HELP_STRING([--enable-x11],
+		[Explicitly enable or disable X11 support
+		(default is to enable only if X development libraries are detected)])],
+	[enable_x11=$enableval],
+	[enable_x11=auto])
+
+AC_ARG_ENABLE(wayland,
+	[AC_HELP_STRING([--enable-wayland],
+		[Explicitly enable or disable Wayland support
+		(default is to enable only if Wayland client development library is detected)])],
+	[enable_wayland=$enableval],
+	[enable_wayland=auto])
+
+dnl Check if we have gtk-layer-shell installed, and thus should build with Wayland support
+have_wayland=no
+if test "x$enable_wayland" != "xno"; then
+	PKG_CHECK_MODULES(NOTIFICATION_DAEMON_WAYLAND, gtk-layer-shell-0, [
+		have_wayland=yes
+		AC_DEFINE(HAVE_WAYLAND, 1, [Have the Wayland development library])
+		NOTIFICATION_DAEMON_CFLAGS="$NOTIFICATION_DAEMON_CFLAGS $NOTIFICATION_DAEMON_WAYLAND_CFLAGS"
+		NOTIFICATION_DAEMON_LIBS="$NOTIFICATION_DAEMON_LIBS $NOTIFICATION_DAEMON_WAYLAND_LIBS"
+	], [
+		if test "x$enable_wayland" = "xyes"; then
+			AC_MSG_ERROR([Wayland enabled but GTK Layer Shell library not found])
+		fi
+	])
+fi
+
+dnl Check if we have the X development libraries
+have_x11=no
+if test "x$enable_x11" != "xno"; then
+	x11_pkg_modules="libwnck-3.0, x11"
+	PKG_CHECK_MODULES(NOTIFICATION_DAEMON_X11, $x11_pkg_modules, [
+		have_x11=yes
+		AC_DEFINE(HAVE_X11, 1, [Have the X11 development library])
+		NOTIFICATION_DAEMON_CFLAGS="$NOTIFICATION_DAEMON_CFLAGS $NOTIFICATION_DAEMON_X11_CFLAGS"
+		NOTIFICATION_DAEMON_LIBS="$NOTIFICATION_DAEMON_LIBS $NOTIFICATION_DAEMON_X11_LIBS"
+	], [
+		AC_MSG_ERROR([Did not find X11])
+		if test "x$enable_x11" = "xyes"; then
+			AC_MSG_ERROR([X development libraries not found])
+		fi
+	])
+fi
+
+AM_CONDITIONAL(ENABLE_WAYLAND, [test "x$have_wayland" = "xyes"])
+AM_CONDITIONAL(ENABLE_X11, [test "x$have_x11" = "xyes"])
+
+if test "x$have_x11" != "xyes" -a "x$have_wayland" != "xyes"; then
+  AC_MSG_ERROR([At least one backend must be enabled (--enable-x11 or --enable-wayland)])
+fi
+
 AC_SUBST(NOTIFICATION_DAEMON_CFLAGS)
 AC_SUBST(NOTIFICATION_DAEMON_LIBS)
 
@@ -244,6 +303,8 @@ echo "
 	compiler:                 ${CC}
 	cflags:	                  ${CFLAGS}
 	warning flags:            ${WARN_CFLAGS}
+	Wayland support:          ${have_wayland}
+	X11 support:              ${have_x11}
 
 	dbus-1 system.d           $DBUS_SYS_DIR
 	dbus-1 services           $DBUS_SERVICES_DIR

--- a/configure.ac
+++ b/configure.ac
@@ -176,7 +176,6 @@ if test "x$enable_x11" != "xno"; then
 		NOTIFICATION_DAEMON_CFLAGS="$NOTIFICATION_DAEMON_CFLAGS $NOTIFICATION_DAEMON_X11_CFLAGS"
 		NOTIFICATION_DAEMON_LIBS="$NOTIFICATION_DAEMON_LIBS $NOTIFICATION_DAEMON_X11_LIBS"
 	], [
-		AC_MSG_ERROR([Did not find X11])
 		if test "x$enable_x11" = "xyes"; then
 			AC_MSG_ERROR([X development libraries not found])
 		fi

--- a/src/capplet/mate-notification-properties.c
+++ b/src/capplet/mate-notification-properties.c
@@ -356,7 +356,7 @@ static void notification_properties_dialog_setup_themes(NotificationAppletDialog
 	}
 	else
 	{
-		g_warning("Error opening themes dir");
+		g_warning("Error opening themes dir %s", ENGINES_DIR);
 	}
 
 	theme = g_settings_get_string(dialog->gsettings, GSETTINGS_KEY_THEME);

--- a/src/daemon/Makefile.am
+++ b/src/daemon/Makefile.am
@@ -12,6 +12,11 @@ mate_notification_daemon_SOURCES = \
 	sound.h \
 	mnd-daemon.c
 
+if ENABLE_WAYLAND
+mate_notification_daemon_SOURCES += \
+	wayland.c
+endif
+
 mate_notification_daemon_LDADD = $(NOTIFICATION_DAEMON_LIBS)
 
 mate_notification_daemon_CFLAGS = $(WARN_CFLAGS)

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -45,6 +45,11 @@
 #include <libwnck/libwnck.h>
 #endif // HAVE_X11
 
+#ifdef HAVE_WAYLAND
+#include <gdk/gdkwayland.h>
+#include "wayland.h"
+#endif // HAVE_WAYLAND
+
 #include "daemon.h"
 #include "engines.h"
 #include "stack.h"
@@ -1369,6 +1374,14 @@ static gboolean notify_daemon_notify_handler(NotifyDaemonNotifications *object, 
 	{
 		nw = theme_create_notification (url_clicked_cb);
 		g_object_set_data (G_OBJECT (nw), "_notify_daemon", daemon);
+
+#if HAVE_WAYLAND
+		if (GDK_IS_WAYLAND_DISPLAY (gdk_display_get_default ()))
+		{
+			wayland_init_notification (nw);
+		}
+#endif // HAVE_WAYLAND
+
 		gtk_widget_realize (GTK_WIDGET (nw));
 		new_notification = TRUE;
 

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -43,7 +43,7 @@
 
 #define WNCK_I_KNOW_THIS_IS_UNSTABLE
 #include <libwnck/libwnck.h>
-#endif // HAVE_X11
+#endif /* HAVE_X11 */
 
 #include "daemon.h"
 #include "engines.h"
@@ -95,7 +95,7 @@ typedef struct {
 	guint         paused : 1;
 #ifdef HAVE_X11
 	Window        src_window_xid;
-#endif // HAVE_X11
+#endif /* HAVE_X11 */
 } NotifyTimeout;
 
 typedef struct {
@@ -103,7 +103,7 @@ typedef struct {
 	gsize n_stacks;
 #ifdef HAVE_X11
 	Atom workarea_atom;
-#endif // HAVE_X11
+#endif /* HAVE_X11 */
 } NotifyScreen;
 
 struct _NotifyDaemon {
@@ -141,7 +141,7 @@ static NotifyStackLocation get_stack_location_from_string(const gchar *slocation
 static GdkFilterReturn _notify_x11_filter(GdkXEvent* xevent, GdkEvent* event, NotifyDaemon* daemon);
 static void sync_notification_position(NotifyDaemon* daemon, GtkWindow* nw, Window source);
 static void monitor_notification_source_windows(NotifyDaemon* daemon, NotifyTimeout* nt, Window source);
-#endif // HAVE_X11
+#endif /* HAVE_X11 */
 
 static gboolean notify_daemon_notify_handler(NotifyDaemonNotifications *object, GDBusMethodInvocation *invocation, const gchar *app_name, guint id, const gchar *icon, const gchar *summary, const gchar *body, const gchar *const *actions, GVariant *hints, gint timeout, gpointer user_data);
 static gboolean notify_daemon_close_notification_handler(NotifyDaemonNotifications *object, GDBusMethodInvocation *invocation, guint arg_id, gpointer user_data);
@@ -400,7 +400,7 @@ static GdkFilterReturn screen_xevent_filter(GdkXEvent* xevent, GdkEvent* event, 
 
 	return GDK_FILTER_CONTINUE;
 }
-#endif // HAVE_X11
+#endif /* HAVE_X11 */
 
 static void create_screen(NotifyDaemon* daemon)
 {
@@ -426,7 +426,7 @@ static void create_screen(NotifyDaemon* daemon)
 		gdk_window_add_filter(gdkwindow, (GdkFilterFunc) screen_xevent_filter, daemon->screen);
 		gdk_window_set_events(gdkwindow, gdk_window_get_events(gdkwindow) | GDK_PROPERTY_CHANGE_MASK);
 	}
-#endif // HAVE_X11
+#endif /* HAVE_X11 */
 
 	create_stacks_for_screen(daemon, screen);
 }
@@ -511,7 +511,7 @@ static void destroy_screen(NotifyDaemon* daemon)
 		gdkwindow = gdk_screen_get_root_window (screen);
 		gdk_window_remove_filter (gdkwindow, (GdkFilterFunc) screen_xevent_filter, daemon->screen);
 	}
-#endif // HAVE_X11
+#endif /* HAVE_X11 */
 
 	for (i = 0; i < daemon->screen->n_stacks; i++) {
 		 g_clear_object (&daemon->screen->stacks[i]);
@@ -536,7 +536,7 @@ static void notify_daemon_finalize(GObject* object)
 	{
 		gdk_window_remove_filter(NULL, (GdkFilterFunc) _notify_x11_filter, daemon);
 	}
-#endif // HAVE_X11
+#endif /* HAVE_X11 */
 
 	if (daemon->skeleton != NULL)
 	{
@@ -759,7 +759,7 @@ static GdkFilterReturn _notify_x11_filter(GdkXEvent* xevent, GdkEvent* event, No
 
 	return GDK_FILTER_CONTINUE;
 }
-#endif // HAVE_X11
+#endif /* HAVE_X11 */
 
 static void _mouse_entered_cb(GtkWindow* nw, GdkEventCrossing* event, NotifyDaemon* daemon)
 {
@@ -1293,7 +1293,7 @@ static void sync_notification_position(NotifyDaemon* daemon, GtkWindow* nw, Wind
 	 */
 	gtk_widget_queue_draw (GTK_WIDGET (nw));
 }
-#endif // HAVE_X11
+#endif /* HAVE_X11 */
 
 GQuark notify_daemon_error_quark(void)
 {
@@ -1329,7 +1329,7 @@ static gboolean notify_daemon_notify_handler(NotifyDaemonNotifications *object, 
 
 #ifdef HAVE_X11
 	Window window_xid = None;
-#endif // HAVE_X11
+#endif /* HAVE_X11 */
 
 	if (g_hash_table_size (daemon->notification_hash) > MAX_NOTIFICATIONS)
 	{
@@ -1397,7 +1397,7 @@ static gboolean notify_daemon_notify_handler(NotifyDaemonNotifications *object, 
 		window_xid = (Window) g_variant_get_uint32 (data);
 		g_variant_unref(data);
 	} else
-#endif // HAVE_X11
+#endif /* HAVE_X11 */
 	/* deal with x, and y hints */
 	if (g_variant_lookup(hints, "x", "i", &x))
 	{
@@ -1509,7 +1509,7 @@ static gboolean notify_daemon_notify_handler(NotifyDaemonNotifications *object, 
 		 */
 	}
 	else
-#endif // HAVE_X11
+#endif /* HAVE_X11 */
 	if (use_pos_data && !theme_get_always_stack (nw))
 	{
 		/*
@@ -1583,14 +1583,14 @@ static gboolean notify_daemon_notify_handler(NotifyDaemonNotifications *object, 
 		monitor_notification_source_windows (daemon, nt, window_xid);
 		sync_notification_position (daemon, nw, window_xid);
 	}
-#endif // HAVE_X11
+#endif /* HAVE_X11 */
 
 	fullscreen_window = FALSE;
 #ifdef HAVE_X11
 	if (GDK_IS_X11_DISPLAY (gdk_display_get_default ()))
 		fullscreen_window = fullscreen_window_exists (GTK_WIDGET (nw));
-#endif // HAVE_X11
-	// fullscreen_window is assumed to be false on Wayland, as there is no trivial way to check
+#endif /* HAVE_X11 */
+	/* fullscreen_window is assumed to be false on Wayland, as there is no trivial way to check */
 
 	/* If there is no timeout, show the notification also if screensaver
 	 * is active or there are fullscreen windows

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -1152,7 +1152,7 @@ static gboolean fullscreen_window_exists(GtkWidget* nw)
 
 	g_return_val_if_fail (GDK_IS_X11_DISPLAY (gdk_display_get_default ()), FALSE);
 
-	wnck_screen = wnck_screen_get(GDK_SCREEN_XNUMBER(gdk_window_get_screen(gtk_widget_get_window(nw))));
+	wnck_screen = wnck_screen_get (GDK_SCREEN_XNUMBER (gdk_window_get_screen (gtk_widget_get_window (nw))));
 
 	wnck_screen_force_update (wnck_screen);
 
@@ -1500,8 +1500,8 @@ static gboolean notify_daemon_notify_handler(NotifyDaemonNotifications *object, 
 
 #ifdef HAVE_X11
 	if (GDK_IS_X11_DISPLAY (gdk_display_get_default ()) &&
-		window_xid != None &&
-		!theme_get_always_stack (nw))
+	    window_xid != None &&
+	    !theme_get_always_stack (nw))
 	{
 		/*
 		 * Do nothing here if we were passed an XID; we'll call

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -45,11 +45,6 @@
 #include <libwnck/libwnck.h>
 #endif // HAVE_X11
 
-#ifdef HAVE_WAYLAND
-#include <gdk/gdkwayland.h>
-#include "wayland.h"
-#endif // HAVE_WAYLAND
-
 #include "daemon.h"
 #include "engines.h"
 #include "stack.h"
@@ -1374,14 +1369,6 @@ static gboolean notify_daemon_notify_handler(NotifyDaemonNotifications *object, 
 	{
 		nw = theme_create_notification (url_clicked_cb);
 		g_object_set_data (G_OBJECT (nw), "_notify_daemon", daemon);
-
-#if HAVE_WAYLAND
-		if (GDK_IS_WAYLAND_DISPLAY (gdk_display_get_default ()))
-		{
-			wayland_init_notification (nw);
-		}
-#endif // HAVE_WAYLAND
-
 		gtk_widget_realize (GTK_WIDGET (nw));
 		new_notification = TRUE;
 

--- a/src/daemon/engines.c
+++ b/src/daemon/engines.c
@@ -29,7 +29,7 @@
 #ifdef HAVE_WAYLAND
 #include <gdk/gdkwayland.h>
 #include "wayland.h"
-#endif // HAVE_WAYLAND
+#endif /* HAVE_WAYLAND */
 
 typedef struct {
 	GModule*    module;
@@ -216,7 +216,7 @@ GtkWindow* theme_create_notification(UrlClickedCb url_clicked_cb)
 	{
 		wayland_init_notification (nw);
 	}
-#endif // HAVE_WAYLAND
+#endif /* HAVE_WAYLAND */
 	return nw;
 }
 
@@ -329,7 +329,7 @@ void theme_move_notification(GtkWindow* nw, int x, int y)
 	{
 		wayland_move_notification (nw, x, y);
 	}
-#endif // HAVE_WAYLAND
+#endif /* HAVE_WAYLAND */
 	ThemeEngine* engine = g_object_get_data(G_OBJECT(nw), "_theme_engine");
 	engine->move_notification(nw, x, y);
 }

--- a/src/daemon/engines.c
+++ b/src/daemon/engines.c
@@ -26,6 +26,11 @@
 #include "daemon.h"
 #include "engines.h"
 
+#ifdef HAVE_WAYLAND
+#include <gdk/gdkwayland.h>
+#include "wayland.h"
+#endif // HAVE_WAYLAND
+
 typedef struct {
 	GModule*    module;
 	guint       ref_count;
@@ -206,6 +211,12 @@ GtkWindow* theme_create_notification(UrlClickedCb url_clicked_cb)
 	GtkWindow* nw = engine->create_notification(url_clicked_cb);
 	g_object_set_data_full(G_OBJECT(nw), "_theme_engine", engine, (GDestroyNotify) theme_engine_unref);
 	engine->ref_count++;
+#if HAVE_WAYLAND
+	if (GDK_IS_WAYLAND_DISPLAY (gdk_display_get_default ()))
+	{
+		wayland_init_notification (nw);
+	}
+#endif // HAVE_WAYLAND
 	return nw;
 }
 
@@ -313,6 +324,12 @@ void theme_clear_notification_actions(GtkWindow* nw)
 
 void theme_move_notification(GtkWindow* nw, int x, int y)
 {
+#if HAVE_WAYLAND
+	if (GDK_IS_WAYLAND_DISPLAY (gdk_display_get_default ()))
+	{
+		wayland_move_notification (nw, x, y);
+	}
+#endif // HAVE_WAYLAND
 	ThemeEngine* engine = g_object_get_data(G_OBJECT(nw), "_theme_engine");
 	engine->move_notification(nw, x, y);
 }

--- a/src/daemon/mnd-daemon.c
+++ b/src/daemon/mnd-daemon.c
@@ -78,6 +78,14 @@ int main (int argc, char *argv[])
 {
 	NotifyDaemon *daemon;
 
+	#if defined(HAVE_X11) && defined(HAVE_WAYLAND)
+		gdk_set_allowed_backends ("wayland,x11");
+	#elif defined(HAVE_WAYLAND)
+		gdk_set_allowed_backends ("wayland");
+	#else
+		gdk_set_allowed_backends ("x11");
+	#endif
+
 	gtk_init(&argc, &argv);
 
 	if (!parse_arguments (&argc, &argv))

--- a/src/daemon/stack.c
+++ b/src/daemon/stack.c
@@ -30,7 +30,7 @@
 #include <X11/Xutil.h>
 #include <X11/Xatom.h>
 #include <gdk/gdkx.h>
-#endif // HAVE_X11
+#endif /* HAVE_X11 */
 
 #define NOTIFY_STACK_SPACING 2
 #define WORKAREA_PADDING 6
@@ -115,7 +115,7 @@ get_work_area (NotifyStack  *stack,
 
         return TRUE;
 }
-#endif // HAVE_X11
+#endif /* HAVE_X11 */
 
 static void
 get_origin_coordinates (NotifyStackLocation stack_location,
@@ -304,7 +304,7 @@ notify_stack_shift_notifications (NotifyStack *stack,
         }
         else
 #endif
-        { // Not using X11
+        { /* Not using X11 */
                 workarea = monitor;
         }
 

--- a/src/daemon/stack.c
+++ b/src/daemon/stack.c
@@ -24,11 +24,13 @@
 #include "engines.h"
 #include "stack.h"
 
+#ifdef HAVE_X11
 #include <X11/Xproto.h>
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <X11/Xatom.h>
 #include <gdk/gdkx.h>
+#endif // HAVE_X11
 
 #define NOTIFY_STACK_SPACING 2
 #define WORKAREA_PADDING 6
@@ -47,6 +49,7 @@ GList* notify_stack_get_windows(NotifyStack *stack)
 	return stack->windows;
 }
 
+#ifdef HAVE_X11
 static gboolean
 get_work_area (NotifyStack  *stack,
                GdkRectangle *rect)
@@ -112,6 +115,7 @@ get_work_area (NotifyStack  *stack,
 
         return TRUE;
 }
+#endif // HAVE_X11
 
 static void
 get_origin_coordinates (NotifyStackLocation stack_location,
@@ -290,9 +294,19 @@ notify_stack_shift_notifications (NotifyStack *stack,
         guint           i;
         guint           n_wins;
 
-        get_work_area (stack, &workarea);
         gdk_monitor_get_geometry (stack->monitor, &monitor);
-        gdk_rectangle_intersect (&monitor, &workarea, &workarea);
+
+#ifdef HAVE_X11
+        if (GDK_IS_X11_DISPLAY (gdk_display_get_default ()))
+        {
+                get_work_area (stack, &workarea);
+                gdk_rectangle_intersect (&monitor, &workarea, &workarea);
+        }
+        else
+#endif
+        { // Not using X11
+                workarea = monitor;
+        }
 
         add_padding_to_rect (&workarea);
 

--- a/src/daemon/wayland.c
+++ b/src/daemon/wayland.c
@@ -1,0 +1,39 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2020 William Wold <wm@wmww.sh>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include "config.h"
+
+#ifndef HAVE_WAYLAND
+#error file should only be built when HAVE_WAYLAND is enabled
+#endif
+
+#include <stdlib.h>
+#include <errno.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <gtk-layer-shell/gtk-layer-shell.h>
+
+#include "wayland.h"
+
+void wayland_init_notification (GtkWindow* nw)
+{
+	gtk_layer_init_for_window (nw);
+}

--- a/src/daemon/wayland.c
+++ b/src/daemon/wayland.c
@@ -37,3 +37,45 @@ void wayland_init_notification (GtkWindow* nw)
 {
 	gtk_layer_init_for_window (nw);
 }
+
+void wayland_move_notification (GtkWindow* nw, int x, int y)
+{
+	GdkWindow *window = gtk_widget_get_window (GTK_WIDGET (nw));
+	GdkMonitor *monitor = gdk_display_get_monitor_at_window (
+		gdk_window_get_display (window),
+		window);
+	GdkRectangle workarea;
+	gdk_monitor_get_workarea (monitor, &workarea);
+	GtkRequisition  req;
+	gtk_widget_get_preferred_size (GTK_WIDGET (nw), NULL, &req);
+	int left_gap = x;
+	int top_gap = y;
+	int right_gap = workarea.width - x - req.width;
+	int bottom_gap = workarea.height - y - req.height;
+
+	if (left_gap < right_gap)
+	{
+		gtk_layer_set_anchor (nw, GTK_LAYER_SHELL_EDGE_LEFT, TRUE);
+		gtk_layer_set_anchor (nw, GTK_LAYER_SHELL_EDGE_RIGHT, FALSE);
+		gtk_layer_set_margin (nw, GTK_LAYER_SHELL_EDGE_LEFT, left_gap);
+	}
+	else
+	{
+		gtk_layer_set_anchor (nw, GTK_LAYER_SHELL_EDGE_LEFT, FALSE);
+		gtk_layer_set_anchor (nw, GTK_LAYER_SHELL_EDGE_RIGHT, TRUE);
+		gtk_layer_set_margin (nw, GTK_LAYER_SHELL_EDGE_RIGHT, right_gap);
+	}
+
+	if (top_gap < bottom_gap)
+	{
+		gtk_layer_set_anchor (nw, GTK_LAYER_SHELL_EDGE_TOP, TRUE);
+		gtk_layer_set_anchor (nw, GTK_LAYER_SHELL_EDGE_BOTTOM, FALSE);
+		gtk_layer_set_margin (nw, GTK_LAYER_SHELL_EDGE_TOP, top_gap);
+	}
+	else
+	{
+		gtk_layer_set_anchor (nw, GTK_LAYER_SHELL_EDGE_TOP, FALSE);
+		gtk_layer_set_anchor (nw, GTK_LAYER_SHELL_EDGE_BOTTOM, TRUE);
+		gtk_layer_set_margin (nw, GTK_LAYER_SHELL_EDGE_BOTTOM, bottom_gap);
+	}
+}

--- a/src/daemon/wayland.c
+++ b/src/daemon/wayland.c
@@ -36,6 +36,8 @@
 void wayland_init_notification (GtkWindow* nw)
 {
 	gtk_layer_init_for_window (nw);
+	gtk_layer_set_layer (nw, GTK_LAYER_SHELL_LAYER_TOP);
+	gtk_layer_set_namespace (nw, "notification");
 }
 
 void wayland_move_notification (GtkWindow* nw, int x, int y)

--- a/src/daemon/wayland.h
+++ b/src/daemon/wayland.h
@@ -30,5 +30,6 @@
 #include <gtk/gtk.h>
 
 void wayland_init_notification (GtkWindow* nw);
+void wayland_move_notification (GtkWindow* nw, int x, int y);
 
 #endif /* _WAYLAND_H */

--- a/src/daemon/wayland.h
+++ b/src/daemon/wayland.h
@@ -1,0 +1,34 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2020 William Wold <wm@wmww.sh>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#ifndef _WAYLAND_H
+#define _WAYLAND_H
+
+#ifdef PACKAGE_NAME // only check HAVE_WAYLAND if config.h has been included
+#ifndef HAVE_WAYLAND
+#error file should only be included when HAVE_WAYLAND is enabled
+#endif
+#endif
+
+#include <gtk/gtk.h>
+
+void wayland_init_notification (GtkWindow* nw);
+
+#endif /* _WAYLAND_H */

--- a/src/daemon/wayland.h
+++ b/src/daemon/wayland.h
@@ -21,7 +21,7 @@
 #ifndef _WAYLAND_H
 #define _WAYLAND_H
 
-#ifdef PACKAGE_NAME // only check HAVE_WAYLAND if config.h has been included
+#ifdef PACKAGE_NAME /* only check HAVE_WAYLAND if config.h has been included */
 #ifndef HAVE_WAYLAND
 #error file should only be included when HAVE_WAYLAND is enabled
 #endif

--- a/src/themes/nodoka/nodoka-theme.c
+++ b/src/themes/nodoka/nodoka-theme.c
@@ -137,8 +137,8 @@ get_size_of_widgets_monitor(GtkWidget *widget, int *width, int *height)
 {
 	GdkWindow *window = gtk_widget_get_window (widget);
 	GdkMonitor *monitor = gdk_display_get_monitor_at_window (
-		gdk_window_get_display (window),
-		window);
+			gdk_window_get_display (window),
+			window);
 	GdkRectangle workarea;
 	gdk_monitor_get_workarea (monitor, &workarea);
 	if (width)  *width  = workarea.width;

--- a/src/themes/nodoka/nodoka-theme.c
+++ b/src/themes/nodoka/nodoka-theme.c
@@ -27,7 +27,6 @@
 
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
-#include <gdk/gdkx.h>
 
 #include <libxml/xpath.h>
 
@@ -133,18 +132,30 @@ activate_link (GtkLabel *label, const char *url, WindowData *windata)
 	return TRUE;
 }
 
+static void
+get_size_of_widgets_monitor(GtkWidget *widget, int *width, int *height)
+{
+	GdkWindow *window = gtk_widget_get_window (widget);
+	GdkMonitor *monitor = gdk_display_get_monitor_at_window (
+		gdk_window_get_display (window),
+		window);
+	GdkRectangle workarea;
+	gdk_monitor_get_workarea (monitor, &workarea);
+	if (width)  *width  = workarea.width;
+	if (height) *height = workarea.height;
+}
+
 /* Set if we have arrow down or arrow up */
 static GtkArrowType
 get_notification_arrow_type(GtkWidget *nw)
 {
 	WindowData *windata = g_object_get_data(G_OBJECT(nw), "windata");
-	int screen_height;
+	int monitor_height;
 
-	screen_height = HeightOfScreen (gdk_x11_screen_get_xscreen (
-		gdk_window_get_screen (gtk_widget_get_window (nw))));
+	get_size_of_widgets_monitor (nw, NULL, &monitor_height);
 
 	if (windata->arrow.position.y + windata->height + DEFAULT_ARROW_HEIGHT >
-		screen_height)
+		monitor_height)
 	{
 		return GTK_ARROW_DOWN;
 	}
@@ -158,12 +169,11 @@ get_notification_arrow_type(GtkWidget *nw)
 static void
 set_arrow_parameters (WindowData *windata)
 {
-	int screen_width;
+	int monitor_width;
 	int x,y;
 	GtkArrowType arrow_type;
 
-	screen_width = WidthOfScreen (gdk_x11_screen_get_xscreen (
-		gdk_window_get_screen (gtk_widget_get_window (windata->win))));
+	get_size_of_widgets_monitor (windata->win, &monitor_width, NULL);
 
 	/* Set arrow offset */
 	GtkAllocation alloc;
@@ -171,11 +181,11 @@ set_arrow_parameters (WindowData *windata)
 
 	if ((windata->arrow.position.x - DEFAULT_ARROW_SKEW -
 		DEFAULT_ARROW_OFFSET + alloc.width) >
-			screen_width)
+			monitor_width)
 	{
 		windata->arrow.offset = windata->arrow.position.x -
 					DEFAULT_ARROW_SKEW -
-					(screen_width -
+					(monitor_width -
 						alloc.width);
 	}
 	else if ((windata->arrow.position.x - DEFAULT_ARROW_SKEW -

--- a/src/themes/standard/Makefile.am
+++ b/src/themes/standard/Makefile.am
@@ -5,8 +5,8 @@ engine_LTLIBRARIES = libstandard.la
 libstandard_la_SOURCES = theme.c
 libstandard_la_CFLAGS = $(WARN_CFLAGS)
 libstandard_la_LDFLAGS = -module -avoid-version -no-undefined
-libstandard_la_LIBADD  = $(NOTIFICATION_DAEMON_LIBS) $(THEME_LIBS)
+libstandard_la_LIBADD  = $(THEME_LIBS)
 
-AM_CPPFLAGS = $(NOTIFICATION_DAEMON_CFLAGS) $(THEME_CFLAGS)
+AM_CPPFLAGS = $(THEME_CFLAGS)
 
 -include $(top_srcdir)/git.mk


### PR DESCRIPTION
Adds `--enable-x11`/`--enable-wayland` options. Like with the panel you can use the configure options to force enable or disable each backend, or not specify them let the build system detect if the required libraries are present. Wayland support requires [GTK Layer Shell](https://github.com/wmww/gtk-layer-shell). I inserted Wayland code and made X11 code optional with minimal additional refactoring, so it's all a bit rough.

What works:
- Notifications appear
- Notifications are correctly placed (at least in the cases I've seen)

What doesn't:
- Suppressing notifications when there is a full screen window—there isn't an obvious way to do that on stock Wayland.
- Selecting the monitor for notifications to appear on—this should be possible, but I haven't implemented it