### PR TITLE
Allow setting the exit timeout

### DIFF
--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -40,6 +40,7 @@
 G_DECLARE_FINAL_TYPE (NotifyDaemon, notify_daemon, NOTIFY, DAEMON, GObject)
 
 #define NOTIFY_DAEMON_DEFAULT_TIMEOUT 7000
+extern int exit_timeout_seconds;
 
 enum {
 	URGENCY_LOW,

--- a/src/daemon/mnd-daemon.c
+++ b/src/daemon/mnd-daemon.c
@@ -46,6 +46,12 @@ static GOptionEntry entries[] =
 		NULL
 	},
 	{
+		"timeout", 't', G_OPTION_FLAG_NONE,
+		G_OPTION_ARG_INT, &exit_timeout_seconds,
+		"Set how long the daemon will sit idle, or -1 to never exit",
+		"seconds"
+	},
+	{
 		NULL
 	}
 };


### PR DESCRIPTION
## Status quo
Previously, 30 seconds after the last notification disappears the daemon exited. This timeout was hard-coded.

## Issue
I can only assume on MATE that some other process is claiming the DBus name and spinning up the daemon whenever a notification comes through. Whatever that process is, it doesn't work when I run the the daemon on Sway without other MATE components running. I have to run it in a service that constantly restarts it, which is annoying.

## Proposal
This PR keeps the 30 seconds as the default and adds a command line option that allows setting it to something else (notably -1 which will disable the timeout).