### PR TITLE
build: Fix make distcheck

### DIFF
--- a/src/daemon/Makefile.am
+++ b/src/daemon/Makefile.am
@@ -14,6 +14,7 @@ mate_notification_daemon_SOURCES = \
 
 if ENABLE_WAYLAND
 mate_notification_daemon_SOURCES += \
+	wayland.h \
 	wayland.c
 endif
 


### PR DESCRIPTION
```
$ ./autogen.sh --prefix=/usr && make && make distcheck
<cut>
../../../../src/daemon/engines.c:31:10: fatal error: wayland.h: El fitxer o directori no existeix
   31 | #include "wayland.h"
      |          ^~~~~~~~~~~
compilation terminated.
make[4]: *** [Makefile:549: mate_notification_daemon-engines.o] Error 1
make[4]: Leaving directory '/home/robert/mate-notification-daemon/mate-notification-daemon-1.25.0/_build/sub/src/daemon'
make[3]: *** [Makefile:402: all-recursive] Error 1
make[3]: Leaving directory '/home/robert/mate-notification-daemon/mate-notification-daemon-1.25.0/_build/sub/src'
make[2]: *** [Makefile:484: all-recursive] Error 1
make[2]: Leaving directory '/home/robert/mate-notification-daemon/mate-notification-daemon-1.25.0/_build/sub'
make[1]: *** [Makefile:416: all] Error 2
make[1]: Leaving directory '/home/robert/mate-notification-daemon/mate-notification-daemon-1.25.0/_build/sub'
make: *** [Makefile:707: distcheck] Error 1
```