### PR TITLE
Don't use g_clear_object() on NotifyStack (which is not a GObject)

### DIFF
--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -512,7 +512,7 @@ static void destroy_screen(NotifyDaemon* daemon)
 #endif /* HAVE_X11 */
 
 	for (i = 0; i < daemon->screen->n_stacks; i++) {
-		 g_clear_object (&daemon->screen->stacks[i]);
+		 g_clear_pointer (&daemon->screen->stacks[i], notify_stack_destroy);
 	}
 
 	g_free (daemon->screen->stacks);


### PR DESCRIPTION
NotifyStack is not a GObject, so calling g_clear_object is bad. Interestingly, it caused an endless loop in `g_object_unref()` on my system due to a quark in how the ref count is checked.