### PR TITLE
Remove shadow warnings [-Wshadow]

### DIFF
--- a/src/capplet/mate-notification-properties.c
+++ b/src/capplet/mate-notification-properties.c
@@ -70,7 +70,7 @@ static void notification_properties_position_notify(GSettings *settings, gchar *
 {
 	GtkTreeModel* model;
 	GtkTreeIter iter;
-	const char* location;
+	const char *location;
 	gboolean valid;
 
 	location = g_settings_get_string(dialog->gsettings, key);
@@ -80,18 +80,17 @@ static void notification_properties_position_notify(GSettings *settings, gchar *
 
 	for (valid = gtk_tree_model_get_iter_first(model, &iter); valid; valid = gtk_tree_model_iter_next(model, &iter))
 	{
-		gchar* key;
+		gchar *it_key;
 
-		gtk_tree_model_get(model, &iter, NOTIFY_POSITION_NAME, &key, -1);
+		gtk_tree_model_get(model, &iter, NOTIFY_POSITION_NAME, &it_key, -1);
 
-		if (g_str_equal(key, location))
+		if (g_str_equal(it_key, location))
 		{
 			gtk_combo_box_set_active_iter(GTK_COMBO_BOX(dialog->position_combo), &iter);
-			g_free(key);
+			g_free(it_key);
 			break;
 		}
-
-		g_free(key);
+		g_free (it_key);
 	}
 }
 

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -1525,7 +1525,6 @@ static gboolean notify_daemon_notify_handler(NotifyDaemonNotifications *object, 
 		GdkSeat *seat;
 		GdkDevice *pointer;
 		GdkScreen* screen;
-		gint x, y;
 
 		theme_set_notification_arrow (nw, FALSE, 0, 0);
 
@@ -1534,12 +1533,19 @@ static gboolean notify_daemon_notify_handler(NotifyDaemonNotifications *object, 
 		 * number the user has set in gsettings. */
 		if (g_settings_get_boolean(daemon->gsettings, GSETTINGS_KEY_USE_ACTIVE_MONITOR))
 		{
+			gint coordinate_x, coordinate_y;
+
 			display = gdk_display_get_default ();
 			seat = gdk_display_get_default_seat (display);
 			pointer = gdk_seat_get_pointer (seat);
 
-			gdk_device_get_position (pointer, &screen, &x, &y);
-			monitor_id = gdk_display_get_monitor_at_point (gdk_screen_get_display (screen), x, y);
+			gdk_device_get_position (pointer,
+			                         &screen,
+			                         &coordinate_x,
+			                         &coordinate_y);
+			monitor_id = gdk_display_get_monitor_at_point (gdk_screen_get_display (screen),
+			                                               coordinate_x,
+			                                               coordinate_y);
 		}
 		else
 		{
@@ -1604,14 +1610,14 @@ static gboolean notify_daemon_notify_handler(NotifyDaemonNotifications *object, 
 	}
 	else
 	{
-		_NotifyPendingClose* data;
+		_NotifyPendingClose *notification_data;
 
 		/* The notification was not shown, so queue up a close
 		 * for it */
-		data = g_new0 (_NotifyPendingClose, 1);
-		data->id = id;
-		data->daemon = g_object_ref (daemon);
-		g_idle_add ((GSourceFunc) _close_notification_not_shown, data);
+		notification_data = g_new0 (_NotifyPendingClose, 1);
+		notification_data->id = id;
+		notification_data->daemon = g_object_ref (daemon);
+		g_idle_add ((GSourceFunc) _close_notification_not_shown, notification_data);
 	}
 
 	g_free (sound_file);


### PR DESCRIPTION
```
daemon.c:1528:8: warning: declaration of ‘x’ shadows a previous local [-Wshadow]
 1528 |   gint x, y;
      |        ^
--
daemon.c:1528:11: warning: declaration of ‘y’ shadows a previous local [-Wshadow]
 1528 |   gint x, y;
      |           ^
--
daemon.c:1607:24: warning: declaration of ‘data’ shadows a previous local [-Wshadow]
 1607 |   _NotifyPendingClose* data;
      |                        ^~~~
--
mate-notification-properties.c:83:10: warning: declaration of ‘key’ shadows a parameter [-Wshadow]
   83 |   gchar* key;
      |          ^~~
```