### PR TITLE
daemon: g_memdup is dreprecated from glib 2.68

### DIFF
--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -909,7 +909,11 @@ static NotifyTimeout* _store_notification(NotifyDaemon* daemon, GtkWindow* nw, i
 
 	_calculate_timeout(daemon, nt, timeout);
 
+#if GLIB_CHECK_VERSION (2, 68, 0)
+	g_hash_table_insert(daemon->notification_hash, g_memdup2(&id, sizeof(guint)), nt);
+#else
 	g_hash_table_insert(daemon->notification_hash, g_memdup(&id, sizeof(guint)), nt);
+#endif
 	remove_exit_timeout(daemon);
 
 	return nt;
@@ -950,8 +954,11 @@ static GdkPixbuf * _notify_daemon_pixbuf_from_data_hint (GVariant *icon_data)
         }
 
         data_size = g_variant_get_size (data_variant);
+#if GLIB_CHECK_VERSION (2, 68, 0)
+        data = (guchar *) g_memdup2 (g_variant_get_data (data_variant), data_size);
+#else
         data = (guchar *) g_memdup (g_variant_get_data (data_variant), (guint) data_size);
-
+#endif
         pixbuf = gdk_pixbuf_new_from_data (data,
                                            GDK_COLORSPACE_RGB,
                                            has_alpha,


### PR DESCRIPTION
```
daemon.c: In function ‘_store_notification’:
daemon.c:912:9: warning: ‘g_memdup’ is deprecated: Use 'g_memdup2' instead [-Wdeprecated-declarations]
  912 |         g_hash_table_insert(daemon->notification_hash, g_memdup(&id, sizeof(guint)), nt);
      |         ^~~~~~~~~~~~~~~~~~~
In file included from /usr/include/glib-2.0/glib.h:82,
                 from /usr/include/glib-2.0/glib/gi18n.h:21,
                 from daemon.c:31:
/usr/include/glib-2.0/glib/gstrfuncs.h:257:23: note: declared here
  257 | gpointer              g_memdup         (gconstpointer mem,
      |                       ^~~~~~~~
daemon.c: In function ‘_notify_daemon_pixbuf_from_data_hint’:
daemon.c:953:9: warning: ‘g_memdup’ is deprecated: Use 'g_memdup2' instead [-Wdeprecated-declarations]
  953 |         data = (guchar *) g_memdup (g_variant_get_data (data_variant), (guint) data_size);
      |         ^~~~
In file included from /usr/include/glib-2.0/glib.h:82,
                 from /usr/include/glib-2.0/glib/gi18n.h:21,
                 from daemon.c:31:
/usr/include/glib-2.0/glib/gstrfuncs.h:257:23: note: declared here
  257 | gpointer              g_memdup         (gconstpointer mem,
      |                       ^~~~~~~~
```