### PR TITLE
Add AssumedAppArmorLabel to dbus service file

### DIFF
--- a/data/org.freedesktop.mate.Notifications.service.in
+++ b/data/org.freedesktop.mate.Notifications.service.in
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=org.freedesktop.Notifications
 Exec=@LIBEXECDIR@/mate-notification-daemon
+AssumedAppArmorLabel=unconfined


### PR DESCRIPTION
Snap packages are unable to trigger the notification daemon in a fully confined package, because the snapd apparmor rules state that the target of the dbus call must specify that it is labelled `unconfined`. See https://forum.snapcraft.io/t/snapd-doesnt-allow-notification-daemon-to-be-activatable/22912/1 for the details.

* Add `AssumedAppArmorLabel` rule to dbus service file