### PR TITLE
mnd-daemon: fix memory leak

### DIFF
--- a/src/daemon/mnd-daemon.c
+++ b/src/daemon/mnd-daemon.c
@@ -63,11 +63,14 @@ static gboolean parse_arguments (int    *argc, char ***argv)
 	error = NULL;
 	if (g_option_context_parse (context, argc, argv, &error) == FALSE)
 	{
+		g_option_context_free (context);
 		g_warning ("Failed to parse command line arguments: %s", error->message);
 		g_error_free (error);
 
 		return FALSE;
 	}
+
+	g_option_context_free (context);
 
 	if (debug)
 		g_setenv ("G_MESSAGES_DEBUG", "all", FALSE);


### PR DESCRIPTION
```
CC=gcc CFLAGS="-ggdb3 -O0 -fsanitize=address" LDFLAGS="-fsanitize=address"  ./autogen.sh --prefix=/usr --enable-debug  --enable-compile-warnings=maximum && make &> make.log && sudo make install
```
```
LeakSanitizer: detected memory leaks
Direct leak of 88 byte(s) in 1 object(s) allocated from:
    #0 0x7fd1deb6baf7 in calloc (/lib64/libasan.so.6+0xaeaf7)
    #1 0x7fd1dda92c04 in g_malloc0 ../glib/gmem.c:136
    #2 0x7fd1dda92f52 in g_malloc0_n ../glib/gmem.c:368
    #3 0x7fd1dda99c4a in g_option_context_new ../glib/goption.c:365
    #4 0x417ce2 in parse_arguments /home/robert/builddir.gcc/mate-notification-daemon/src/daemon/mnd-daemon.c:59
    #5 0x417f17 in main /home/robert/builddir.gcc/mate-notification-daemon/src/daemon/mnd-daemon.c:92
    #6 0x7fd1dd70ab74 in __libc_start_main (/lib64/libc.so.6+0x27b74)
Indirect leak of 112 byte(s) in 1 object(s) allocated from:
    #0 0x7fd1deb6baf7 in calloc (/lib64/libasan.so.6+0xaeaf7)
    #1 0x7fd1dda92c04 in g_malloc0 ../glib/gmem.c:136
    #2 0x7fd1dda92f52 in g_malloc0_n ../glib/gmem.c:368
    #3 0x7fd1dda9a7aa in g_option_group_new ../glib/goption.c:2323
    #4 0x7fd1dda9a745 in g_option_context_add_main_entries ../glib/goption.c:667
    #5 0x417cfc in parse_arguments /home/robert/builddir.gcc/mate-notification-daemon/src/daemon/mnd-daemon.c:61
    #6 0x417f17 in main /home/robert/builddir.gcc/mate-notification-daemon/src/daemon/mnd-daemon.c:92
    #7 0x7fd1dd70ab74 in __libc_start_main (/lib64/libc.so.6+0x27b74)
Indirect leak of 96 byte(s) in 1 object(s) allocated from:
    #0 0x7fd1deb6bcb8 in __interceptor_realloc (/lib64/libasan.so.6+0xaecb8)
    #1 0x7fd1dda92c97 in g_realloc ../glib/gmem.c:171
    #2 0x7fd1dda92fea in g_realloc_n ../glib/gmem.c:394
    #3 0x7fd1dda9a938 in g_option_group_add_entries ../glib/goption.c:2427
    #4 0x7fd1dda9a761 in g_option_context_add_main_entries ../glib/goption.c:669
    #5 0x417cfc in parse_arguments /home/robert/builddir.gcc/mate-notification-daemon/src/daemon/mnd-daemon.c:61
    #6 0x417f17 in main /home/robert/builddir.gcc/mate-notification-daemon/src/daemon/mnd-daemon.c:92
    #7 0x7fd1dd70ab74 in __libc_start_main (/lib64/libc.so.6+0x27b74)
SUMMARY: AddressSanitizer: 296 byte(s) leaked in 3 allocation(s).
```