### PR TITLE
daemon: fix memory leak

### DIFF
--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -1685,10 +1685,10 @@ static gboolean notify_daemon_get_server_information (NotifyDaemonNotifications 
 {
 	notify_daemon_notifications_complete_get_server_information(object,
 			invocation,
-			g_strdup("Notification Daemon"),
-			g_strdup("MATE"),
-			g_strdup(PACKAGE_VERSION),
-			g_strdup("1.1"));
+			"Notification Daemon",
+			"MATE",
+			PACKAGE_VERSION,
+			"1.1");
 	return TRUE;
 }
 


### PR DESCRIPTION
```
==1968==ERROR: LeakSanitizer: detected memory leaks
Direct leak of 20 byte(s) in 1 object(s) allocated from:
    #0 0x7f0a4cb9793f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7f0a4babeb7f in g_malloc ../glib/gmem.c:106
    #2 0x7f0a4babeec2 in g_malloc_n ../glib/gmem.c:344
    #3 0x7f0a4bae11a5 in g_strdup ../glib/gstrfuncs.c:364
    #4 0x413d71 in notify_daemon_get_server_information /home/robert/builddir.gcc/mate-notification-daemon/src/daemon/daemon.c:1688
    #5 0x7f0a4ad0ac03 in ffi_call_unix64 (/lib64/libffi.so.6+0x6c03)
    #6 0x7ffd4a2af5af  ([stack]+0x1f5af)
Direct leak of 7 byte(s) in 1 object(s) allocated from:
    #0 0x7f0a4cb9793f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7f0a4babeb7f in g_malloc ../glib/gmem.c:106
    #2 0x7f0a4babeec2 in g_malloc_n ../glib/gmem.c:344
    #3 0x7f0a4bae11a5 in g_strdup ../glib/gstrfuncs.c:364
    #4 0x413d57 in notify_daemon_get_server_information /home/robert/builddir.gcc/mate-notification-daemon/src/daemon/daemon.c:1690
    #5 0x7f0a4ad0ac03 in ffi_call_unix64 (/lib64/libffi.so.6+0x6c03)
    #6 0x7ffd4a2af5af  ([stack]+0x1f5af)
Direct leak of 5 byte(s) in 1 object(s) allocated from:
    #0 0x7f0a4cb9793f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7f0a4babeb7f in g_malloc ../glib/gmem.c:106
    #2 0x7f0a4babeec2 in g_malloc_n ../glib/gmem.c:344
    #3 0x7f0a4bae11a5 in g_strdup ../glib/gstrfuncs.c:364
    #4 0x413d64 in notify_daemon_get_server_information /home/robert/builddir.gcc/mate-notification-daemon/src/daemon/daemon.c:1689
    #5 0x7f0a4ad0ac03 in ffi_call_unix64 (/lib64/libffi.so.6+0x6c03)
    #6 0x7ffd4a2af5af  ([stack]+0x1f5af)
Direct leak of 4 byte(s) in 1 object(s) allocated from:
    #0 0x7f0a4cb9793f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7f0a4babeb7f in g_malloc ../glib/gmem.c:106
    #2 0x7f0a4babeec2 in g_malloc_n ../glib/gmem.c:344
    #3 0x7f0a4bae11a5 in g_strdup ../glib/gstrfuncs.c:364
    #4 0x413d4a in notify_daemon_get_server_information /home/robert/builddir.gcc/mate-notification-daemon/src/daemon/daemon.c:1691
    #5 0x7f0a4ad0ac03 in ffi_call_unix64 (/lib64/libffi.so.6+0x6c03)
    #6 0x7ffd4a2af5af  ([stack]+0x1f5af)
```