### PR TITLE
build: show configure summary using a pretty format

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -302,22 +302,24 @@ src/themes/standard/Makefile
 AC_OUTPUT
 
 echo "
-			$PACKAGE_NAME $PACKAGE_VERSION
-			================================
+Configure summary:
 
-	prefix:                   ${prefix}
-	exec_prefix:              ${exec_prefix}
-	bindir:                   ${bindir}
-	datadir:                  ${datadir}
-	source code location:     ${srcdir}
-	compiler:                 ${CC}
-	cflags:	                  ${CFLAGS}
-	warning flags:            ${WARN_CFLAGS}
-	Wayland support:          ${have_wayland}
-	X11 support:              ${have_x11}
-	Native Language support:  ${USE_NLS}
+    ${PACKAGE_STRING}
+    `echo $PACKAGE_STRING | sed "s/./=/g"`
 
-	dbus-1 system.d           $DBUS_SYS_DIR
-	dbus-1 services           $DBUS_SERVICES_DIR
+    prefix ......................: ${prefix}
+    exec_prefix .................: ${exec_prefix}
+    bindir ......................: ${bindir}
+    datadir .....................: ${datadir}
+    source code location ........: ${srcdir}
+    compiler ....................: ${CC}
+    cflags ......................: ${CFLAGS}
+    warning flags ...............: ${WARN_CFLAGS}
+    Wayland support .............: ${have_wayland}
+    X11 support .................: ${have_x11}
+    Native Language support .....: ${USE_NLS}
+
+    dbus-1 system.d .............: $DBUS_SYS_DIR
+    dbus-1 services .............: $DBUS_SERVICES_DIR
 
 "


### PR DESCRIPTION
sample output:
```
Configure summary:

    mate-notification-daemon 1.26.0
    ===============================

    prefix ......................: /usr
    exec_prefix .................: ${prefix}
    bindir ......................: ${exec_prefix}/bin
    datadir .....................: ${datarootdir}
    source code location ........: .
    compiler ....................: gcc
    cflags ......................: -g -O2
    warning flags ...............: -Wall -Wmissing-prototypes
    Wayland support .............: yes
    X11 support .................: yes
    Native Language support .....: yes

    dbus-1 system.d .............: /etc/dbus-1/system.d
    dbus-1 services .............: ${prefix}/share/dbus-1/services


Now type `make' to compile mate-notification-daemon
```