### PR TITLE
Fix build warnings about missing field initializer

### DIFF
--- a/src/capplet/mate-notification-properties.c
+++ b/src/capplet/mate-notification-properties.c
@@ -509,11 +509,12 @@ static void notification_properties_dialog_finalize(NotificationAppletDialog* di
 		notify_notification_close(dialog->preview, NULL);
 		dialog->preview = NULL;
 	}
+	g_free (dialog);
 }
 
 int main(int argc, char** argv)
 {
-	NotificationAppletDialog dialog = {NULL, }; /* <- ? */
+	NotificationAppletDialog *dialog;
 
 #ifdef ENABLE_NLS
 	bindtextdomain(GETTEXT_PACKAGE, NOTIFICATION_LOCALEDIR);
@@ -525,15 +526,16 @@ int main(int argc, char** argv)
 
 	notify_init("mate-notification-properties");
 
-	if (!notification_properties_dialog_init(&dialog))
+	dialog = g_new0 (NotificationAppletDialog, 1);
+	if (!notification_properties_dialog_init (dialog))
 	{
-		notification_properties_dialog_finalize(&dialog);
+		notification_properties_dialog_finalize (dialog);
 		return 1;
 	}
 
 	gtk_main();
 
-	notification_properties_dialog_finalize(&dialog);
+	notification_properties_dialog_finalize (dialog);
 
 	return 0;
 }

--- a/src/daemon/mnd-daemon.c
+++ b/src/daemon/mnd-daemon.c
@@ -47,7 +47,7 @@ static GOptionEntry entries[] =
 		NULL
 	},
 	{
-		NULL
+		NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL
 	}
 };
 


### PR DESCRIPTION
```
mnd-daemon.c:51:2: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
        }
        ^
--
mate-notification-properties.c:516:43: warning: missing field 'dialog' initializer [-Wmissing-field-initializers]
        NotificationAppletDialog dialog = {NULL, }; /* <- ? */
                                                 ^
```