### PR TITLE
Daemon: do not timeout when running under wayland

### DIFF
--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -261,6 +261,15 @@ static gboolean do_exit(gpointer user_data)
 
 static void add_exit_timeout(NotifyDaemon* daemon)
 {
+	GdkDisplay *display = gdk_screen_get_display (gdk_screen_get_default());
+	/*Do not timeout if not running in X11 As wayland sessions are usually controlled
+	 *by the wayland compositor. We need to keep the daemon running on wayland for now.
+	 *In the future, it may be possible to bring back the timeout on wayland to reduce
+	* the  number of daemons running at all time. This would depend on how dbus
+	* interaction in the final released mate-wayland session works
+	 */
+	if (!(GDK_IS_X11_DISPLAY (display)))
+		return;
 	g_assert (daemon != NULL);
 
 	if (daemon->exit_timeout_source > 0)


### PR DESCRIPTION
When running in any current wayland session we need to keep the daemon alive as restarting it when a notification is sent does not work.