### PR TITLE
auto-start m-n-d with session 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -284,6 +284,7 @@ AM_CONDITIONAL([ICON_UPDATE], [test -n "$UPDATE_ICON_CACHE"])
 AC_CONFIG_FILES([
 Makefile
 data/Makefile
+data/mate-notification-daemon.desktop.in
 data/org.freedesktop.mate.Notifications.service
 data/org.mate.applets.MateNotificationApplet.desktop.in
 data/org.mate.NotificationDaemon.gschema.xml

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -16,6 +16,17 @@ servicedir       = $(DBUS_SERVICES_DIR)
 service_DATA     = org.freedesktop.mate.Notifications.service org.mate.panel.applet.MateNotificationAppletFactory.service
 service_in_files = $(service_DATA:=.in)
 
+autostartdir   = $(sysconfdir)/xdg/autostart
+autostart_in_files = mate-notification-daemon.desktop.in
+autostart_DATA = $(autostart_in_files:.desktop.in=.desktop)
+
+$(autostart_DATA): $(autostart_in_files)
+if USE_NLS
+	$(AM_V_GEN) $(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
+else
+	$(AM_V_GEN) sed '/^# Translators/d' < $< > $@
+endif
+
 appletdir        = $(datadir)/mate-panel/applets
 applet_DATA      = org.mate.applets.MateNotificationApplet.mate-panel-applet
 applet_in_files  = $(applet_DATA:.mate-panel-applet=.desktop.in)
@@ -43,6 +54,7 @@ gsettingsschema_in_files = $(gsettings_SCHEMAS:=.in)
 @GSETTINGS_RULES@
 
 EXTRA_DIST = \
+	$(autostart_in_files) \
 	$(desktop_in_files) \
 	$(gsettingsschema_in_files) \
 	$(icon16_DATA) \
@@ -53,6 +65,7 @@ EXTRA_DIST = \
 	$(iconscalable_DATA)
 
 CLEANFILES = \
+	$(autostart_DATA) \
 	$(applet_DATA) \
 	$(desktop_DATA) \
 	$(gsettings_SCHEMAS)

--- a/data/mate-notification-daemon.desktop.in.in
+++ b/data/mate-notification-daemon.desktop.in.in
@@ -1,0 +1,14 @@
+[Desktop Entry]
+Name=MATE Notification Daemon
+Comment=Display notifications
+Exec=@LIBEXECDIR@/mate-notification-daemon
+Terminal=false
+Type=Application
+OnlyShowIn=MATE;
+NoDisplay=true
+X-MATE-Autostart-Phase=Application
+X-MATE-Autostart-Notify=true
+X-MATE-Bugzilla-Bugzilla=MATE
+X-MATE-Bugzilla-Product=mate-notification-daemon
+X-MATE-Bugzilla-Component=general
+X-MATE-Bugzilla-Version=@VERSION@

--- a/data/org.freedesktop.mate.Notifications.service.in
+++ b/data/org.freedesktop.mate.Notifications.service.in
@@ -1,4 +1,4 @@
 [D-BUS Service]
 Name=org.freedesktop.Notifications
-Exec=@LIBEXECDIR@/mate-notification-daemon
+Exec=@LIBEXECDIR@/mate-notification-daemon --idle-exit
 AssumedAppArmorLabel=unconfined

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -1126,6 +1126,7 @@ static gboolean screensaver_active(GtkWidget* nw)
 	if (proxy == NULL) {
 		g_warning("Failed to get dbus connection: %s", error->message);
 		g_error_free (error);
+		return active;
 	}
 
 	variant = g_dbus_proxy_call_sync (proxy,

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -51,7 +51,8 @@ typedef enum {
 
 G_BEGIN_DECLS
 
-NotifyDaemon*     notify_daemon_new        (gboolean replace);
+NotifyDaemon*     notify_daemon_new        (gboolean replace,
+                                            gboolean idle_exit);
 
 GQuark notify_daemon_error_quark(void);
 

--- a/src/daemon/mnd-daemon.c
+++ b/src/daemon/mnd-daemon.c
@@ -31,6 +31,7 @@
 
 static gboolean debug = FALSE;
 static gboolean replace = FALSE;
+static gboolean idle_exit = FALSE;
 
 static GOptionEntry entries[] =
 {
@@ -44,6 +45,12 @@ static GOptionEntry entries[] =
 		"replace", 'r', G_OPTION_FLAG_NONE,
 		G_OPTION_ARG_NONE, &replace,
 		"Replace a currently running application",
+		NULL
+	},
+	{
+		"idle-exit", 'i', G_OPTION_FLAG_NONE,
+		G_OPTION_ARG_NONE, &idle_exit,
+		"Auto-exit when idle, useful if run through D-Bus activation",
 		NULL
 	},
 	{
@@ -95,7 +102,7 @@ int main (int argc, char *argv[])
 	if (!parse_arguments (&argc, &argv))
 		return EXIT_FAILURE;
 
-	daemon = notify_daemon_new (replace);
+	daemon = notify_daemon_new (replace, idle_exit);
 
 	gtk_main();
 


### PR DESCRIPTION
This is a proof-of-concept rework of an very old PR from 2013.
https://github.com/mate-desktop/mate-notification-daemon/pull/10
It removes dbus-activation for notification-daemon and the daemon will start via autostart folder in x11 and wayland session.

Relying on D-Bus activation to launch org.freedesktop.Notifications can result in a race condition if multiple daemons are present on one computer, as explained further in the commit messages.

For example, GNOME 2.x vs KDE:
http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=584859
https://bugs.kde.org/show_bug.cgi?id=212656

And KDE vs. Unity (notify-osd):
http://ubuntuforums.org/showthread.php?t=1973315

These are just examples. The general problem is discussed further here:
https://bugzilla.redhat.com/show_bug.cgi?id=484945

We have several reports about conflict with kde-notification when both enviroments are installed.
This PR should fix the issues.

I like to test this for myself a while because i am not sure about the consequences.
In wayfire session the daemon can be started via autostart-command in wayfire.ini.