### PR TITLE
Wayland: Allow building do not disturb applet in process

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -198,6 +198,28 @@ if test "x$have_x11" != "xyes" -a "x$have_wayland" != "xyes"; then
   AC_MSG_ERROR([At least one backend must be enabled (--enable-x11 or --enable-wayland)])
 fi
 
+AC_ARG_ENABLE([in-process],
+              [AS_HELP_STRING([--enable-in-process],
+                              [Build do not disturb applet in-process so it can be used in wayland])],
+              [enable_in_process=$enableval],
+              [enable_in_process=no])
+
+# Automake conditional on whether to build in-process
+AM_CONDITIONAL([ENABLE_IN_PROCESS], [test "x$enable_in_process" = "xyes"])
+# Automake value expected to be substitued in .mate-panel-apple.* for the value of "InProcess"
+AS_IF([test "x$enable_in_process" = "xyes"],
+      [AC_SUBST([ENABLE_IN_PROCESS], [true])],
+      [AC_SUBST([ENABLE_IN_PROCESS], [false])])
+# C conditional on whether to build in-process
+AS_IF([test "x$enable_in_process" = "xyes"],
+      [AC_DEFINE([ENABLE_IN_PROCESS], [1], [building in-process])])
+
+# Convenience C define selecting the right applet factory
+AS_IF([test "x$enable_in_process" = "xyes"],
+      [factory=MATE_PANEL_APPLET_IN_PROCESS_FACTORY],
+      [factory=MATE_PANEL_APPLET_OUT_PROCESS_FACTORY])
+AC_DEFINE_UNQUOTED([PANEL_APPLET_FACTORY], [$factory], [Panel applet factory])
+
 AC_SUBST(NOTIFICATION_DAEMON_CFLAGS)
 AC_SUBST(NOTIFICATION_DAEMON_LIBS)
 
@@ -250,6 +272,11 @@ AS_AC_EXPAND(SYSCONFDIR, $sysconfdir)
 AS_AC_EXPAND(LIBDIR, $libdir)
 AS_AC_EXPAND(DATADIR, $datadir)
 AS_AC_EXPAND(LIBEXECDIR, $libexecdir)
+
+# Get the applet location
+AS_IF([test "x$enable_in_process" = "xyes"],
+      [AS_AC_EXPAND(APPLET_LOCATION, $libdir/mate-notification-daemon/libmate-notification-applet.so)],
+      [AS_AC_EXPAND(APPLET_LOCATION, $libexecdir/mate-notification-applet)])
 
 AC_ARG_WITH(dbus-sys, [  --with-dbus-sys=<dir>   where D-BUS system.d directory is])
 AC_ARG_WITH(dbus-services, [  --with-dbus-services=<dir>   where D-BUS services directory is])
@@ -318,6 +345,7 @@ Configure summary:
     warning flags ...............: ${WARN_CFLAGS}
     Wayland support .............: ${have_wayland}
     X11 support .................: ${have_x11}
+    Applet in-process............: ${enable_in_process}
     Native Language support .....: ${USE_NLS}
 
     dbus-1 system.d .............: $DBUS_SYS_DIR

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -12,9 +12,15 @@ icon32_DATA = icons/32x32/mate-notification-properties.png
 icon48_DATA = icons/48x48/mate-notification-properties.png
 iconscalable_DATA = icons/scalable/mate-notification-properties.svg
 
+if ENABLE_IN_PROCESS
+servicedir       = $(DBUS_SERVICES_DIR)
+service_DATA     = org.freedesktop.mate.Notifications.service
+service_in_files = $(service_DATA:=.in)
+else
 servicedir       = $(DBUS_SERVICES_DIR)
 service_DATA     = org.freedesktop.mate.Notifications.service org.mate.panel.applet.MateNotificationAppletFactory.service
 service_in_files = $(service_DATA:=.in)
+endif
 
 autostartdir   = $(sysconfdir)/xdg/autostart
 autostart_in_files = mate-notification-daemon.desktop.in

--- a/data/org.mate.applets.MateNotificationApplet.desktop.in.in
+++ b/data/org.mate.applets.MateNotificationApplet.desktop.in.in
@@ -1,6 +1,7 @@
 [Applet Factory]
 Id=MateNotificationAppletFactory
-Location=@LIBEXECDIR@/mate-notification-applet
+Location=@APPLET_LOCATION@
+InProcess=@ENABLE_IN_PROCESS@
 Name=Mate Notification Applet Factory
 Description=Mate Notification Applet Factory
 

--- a/src/capplet/Makefile.am
+++ b/src/capplet/Makefile.am
@@ -3,8 +3,12 @@ define generate_resources_deps
 endef
 
 bin_PROGRAMS = mate-notification-properties
-libexec_PROGRAMS = mate-notification-applet
 
+if ENABLE_IN_PROCESS
+pkglib_LTLIBRARIES = libmate-notification-applet.la
+else
+libexec_PROGRAMS = mate-notification-applet
+endif
 NULL =
 
 mate_notification_properties_CFLAGS = \
@@ -35,6 +39,33 @@ mate_notification_properties_SOURCES = \
 
 man_MANS = mate-notification-properties.1
 
+if ENABLE_IN_PROCESS
+
+libmate_notification_applet_la_SOURCES = \
+	$(mate_notification_applet_resources_files) \
+	../common/constants.h \
+	mate-notification-applet.c \
+	$(NULL)
+
+libmate_notification_applet_la_CFLAGS = \
+	-I$(top_srcdir)/src/common \
+	$(NOTIFICATION_APPLET_CFLAGS) \
+	-DMATELOCALEDIR=\"$(datadir)/locale\" \
+	-DRESOURCE_PATH=\""/org/mate/panel/applet/notifications/"\" \
+	$(WARN_CFLAGS) \
+	$(NULL)
+
+libmate_notification_applet_la_LIBADD = \
+	$(NOTIFICATION_APPLET_LIBS) \
+	$(NULL)
+
+else
+mate_notification_applet_SOURCES = \
+	$(mate_notification_applet_resources_files) \
+	../common/constants.h \
+	mate-notification-applet.c \
+	$(NULL)
+
 mate_notification_applet_CFLAGS = \
 	-I$(top_srcdir)/src/common \
 	$(NOTIFICATION_APPLET_CFLAGS) \
@@ -47,17 +78,15 @@ mate_notification_applet_LDADD = \
 	$(NOTIFICATION_APPLET_LIBS) \
 	$(NULL)
 
+endif
+
 mate_notification_applet_resources_xml   = org.mate.panel.applet.notifications.gresource.xml
 mate_notification_applet_resources_deps  = $(call generate_resources_deps $(mate_notification_applet_resources_xml))
 mate_notification_applet_resources_files = mate-notification-applet-resources.h mate-notification-applet-resources.c
 $(mate_notification_applet_resources_files): $(mate_notification_applet_resources_xml) Makefile $(mate_notification_applet_resources_deps)
 	$(AM_V_GEN) XMLLINT=$(XMLLINT) $(GLIB_COMPILE_RESOURCES) $< \
 		--target $@ --sourcedir $(srcdir) --generate --c-name notification_applet
-mate_notification_applet_SOURCES = \
-	$(mate_notification_applet_resources_files) \
-	../common/constants.h \
-	mate-notification-applet.c \
-	$(NULL)
+
 
 BUILT_SOURCES = \
 	$(mate_notification_properties_resources_files) \

--- a/src/capplet/mate-notification-applet.c
+++ b/src/capplet/mate-notification-applet.c
@@ -173,16 +173,19 @@ applet_main (MatePanelApplet *applet_widget)
   textdomain (GETTEXT_PACKAGE);
 #endif /* ENABLE_NLS */
 
+#ifndef ENABLE_IN_PROCESS
   g_set_application_name (_("Do Not Disturb"));
+#endif
   gtk_window_set_default_icon_name ("mate-notification-properties");
 
   applet = g_new (MateNotificationApplet, 1);
   applet->applet = applet_widget;
   applet->settings = g_settings_new (GSETTINGS_SCHEMA);
 
+#ifndef ENABLE_IN_PROCESS
   /* needed to clamp ourselves to the panel size */
   mate_panel_applet_set_flags (MATE_PANEL_APPLET (applet), MATE_PANEL_APPLET_EXPAND_MINOR);
-
+#endif
   box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
 
   applet->image_on  = gtk_image_new ();
@@ -257,7 +260,7 @@ applet_factory (MatePanelApplet *applet_widget,
   return FALSE;
 }
 
-MATE_PANEL_APPLET_OUT_PROCESS_FACTORY ("MateNotificationAppletFactory",
+PANEL_APPLET_FACTORY ("MateNotificationAppletFactory",
                                        PANEL_TYPE_APPLET,
                                        "Do Not Disturb Applet",
                                        applet_factory,


### PR DESCRIPTION
Allow building the do not disturb panel applet in-process, it can then be used in wayland