### PR TITLE
applet: Fix i18n

### DIFF
--- a/src/capplet/mate-notification-applet.c
+++ b/src/capplet/mate-notification-applet.c
@@ -22,7 +22,7 @@
 #include "config.h"
 
 #include <glib.h>
-#include <glib/gi18n.h>
+#include <glib/gi18n-lib.h>
 #include <gtk/gtk.h>
 #include <mate-panel-applet.h>
 
@@ -166,12 +166,6 @@ applet_main (MatePanelApplet *applet_widget)
 {
   MateNotificationApplet *applet;
   GtkWidget *box;
-
-#ifdef ENABLE_NLS
-  bindtextdomain (GETTEXT_PACKAGE, MATELOCALEDIR);
-  bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
-  textdomain (GETTEXT_PACKAGE);
-#endif /* ENABLE_NLS */
 
 #ifndef ENABLE_IN_PROCESS
   g_set_application_name (_("Do Not Disturb"));

--- a/src/capplet/mate-notification-applet.c
+++ b/src/capplet/mate-notification-applet.c
@@ -193,8 +193,8 @@ applet_main (MatePanelApplet *applet_widget)
 
   applet_draw_icon (applet_widget, 0, applet);
 
-  gtk_widget_set_tooltip_text (applet->image_off, N_("Do Not Disturb"));
-  gtk_widget_set_tooltip_text (applet->image_on, N_("Notifications Enabled"));
+  gtk_widget_set_tooltip_text (applet->image_off, _("Do Not Disturb"));
+  gtk_widget_set_tooltip_text (applet->image_on, _("Notifications Enabled"));
 
   gtk_box_pack_start (GTK_BOX (box), applet->image_on,
                       TRUE, TRUE, 0);
@@ -215,8 +215,8 @@ applet_main (MatePanelApplet *applet_widget)
                                 G_N_ELEMENTS (applet_menu_actions), applet);
 
   GtkToggleAction *do_not_disturb_toggle_action =
-    gtk_toggle_action_new ("DoNotDisturb", N_("_Do not disturb"),
-                           N_("Enable/Disable do-not-disturb mode."), NULL);
+    gtk_toggle_action_new ("DoNotDisturb", _("_Do not disturb"),
+                           _("Enable/Disable do-not-disturb mode."), NULL);
 
   gtk_action_group_add_action (applet->action_group,
                                GTK_ACTION (do_not_disturb_toggle_action));


### PR DESCRIPTION
Prevent the applet from breaking mate-panel's own translations, and make the applet actually use its translations (which it ironically didn't do, which meant it broke mate-panel's ones for nothing at all)