### PR TITLE
fix building with libxml 2.12.0

### DIFF
--- a/src/themes/coco/coco-theme.c
+++ b/src/themes/coco/coco-theme.c
@@ -28,6 +28,8 @@
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
 
+#include <libxml/parser.h>
+#include <libxml/xmlmemory.h>
 #include <libxml/xpath.h>
 
 /* Define basic coco types */

--- a/src/themes/nodoka/nodoka-theme.c
+++ b/src/themes/nodoka/nodoka-theme.c
@@ -27,6 +27,8 @@
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
 
+#include <libxml/parser.h>
+#include <libxml/xmlmemory.h>
 #include <libxml/xpath.h>
 
 /* Define basic nodoka types */

--- a/src/themes/slider/theme.c
+++ b/src/themes/slider/theme.c
@@ -26,6 +26,8 @@
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
 
+#include <libxml/parser.h>
+#include <libxml/xmlmemory.h>
 #include <libxml/xpath.h>
 
 typedef void (*ActionInvokedCb) (GtkWindow* nw, const char* key);

--- a/src/themes/standard/theme.c
+++ b/src/themes/standard/theme.c
@@ -25,6 +25,8 @@
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
 
+#include <libxml/parser.h>
+#include <libxml/xmlmemory.h>
 #include <libxml/xpath.h>
 
 typedef void (*ActionInvokedCb) (GtkWindow* nw, const char* key);


### PR DESCRIPTION
```
coco-theme.c: In function 'set_notification_text':
coco-theme.c:509:9: error: implicit declaration of function 'xmlInitParser' [-Werror=implicit-function-declaration]
509 |         xmlInitParser();
|         ^~~~~~~~~~~~~
coco-theme.c:513:15: error: implicit declaration of function 'xmlReadMemory'; did you mean 'xmlInitMemory'? [-Werror=implicit-function-declaration]
513 |         doc = xmlReadMemory(str, (int) str_len, "noname.xml", NULL, 0);
|               ^~~~~~~~~~~~~
|               xmlInitMemory
coco-theme.c:513:13: warning: assignment to 'xmlDocPtr' {aka 'struct _xmlDoc *'} from 'int' makes pointer from integer without a cast [-Wint-conversion]
513 |         doc = xmlReadMemory(str, (int) str_len, "noname.xml", NULL, 0);
|             ^
coco-theme.c:561:9: error: implicit declaration of function 'xmlCleanupParser' [-Werror=implicit-function-declaration]
561 |         xmlCleanupParser ();
|         ^~~~~~~~~~~~~~~~
```
Same warnings are in other themes.
Successful build with libxml-2.12.0 from fedora-rawhide at fedora build-server.
https://koji.fedoraproject.org/koji/taskinfo?taskID=109502322
https://src.fedoraproject.org/rpms/mate-notification-daemon/blob/rawhide/f/mate-notification-daemon.spec#_32