### PR TITLE
daemon: Properly update the set of monitors when it changes

### DIFF
--- a/src/daemon/stack.c
+++ b/src/daemon/stack.c
@@ -50,6 +50,11 @@ GList* notify_stack_get_windows(NotifyStack *stack)
 	return stack->windows;
 }
 
+GdkMonitor* notify_stack_get_monitor(NotifyStack *stack)
+{
+	return stack->monitor;
+}
+
 #ifdef HAVE_X11
 static gboolean
 get_work_area (NotifyStack  *stack,

--- a/src/daemon/stack.h
+++ b/src/daemon/stack.h
@@ -46,6 +46,7 @@ void notify_stack_set_location(NotifyStack* stack, NotifyStackLocation location)
 void notify_stack_add_window(NotifyStack* stack, GtkWindow* nw, gboolean new_notification);
 void notify_stack_remove_window(NotifyStack* stack, GtkWindow* nw);
 GList* notify_stack_get_windows(NotifyStack* stack);
+GdkMonitor* notify_stack_get_monitor(NotifyStack* stack);
 void notify_stack_queue_update_position(NotifyStack* stack);
 
 #endif /* _NOTIFY_STACK_H_ */


### PR DESCRIPTION
May fix #218, or part of it.

Beware the I didn't test this myself, but @joakim-tjernlund did.  We need more testing, and see whether this effectively fixes the issues as reproduced by @raveit65 and @lukefromdc, as the fix here is related to monitors changing, while their reproducers might not have been.

The fix here is for properly updating the list of available monitors when that set changes. Before this patch, only the last monitor(s) would be removed, rather than the one(s) that got removed, which should cause issues if the primary monitor is removed, or more generally if any but the last is removed. While having this issue unnoticed could be a bit surprising, I suppose it is fairly unusual to disconnect the primary monitor, and was fairly unusual as well to have more than 2.