### PR TITLE
fix random crash of mate-notification-daemon

### DIFF
--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -266,7 +266,7 @@ static void _notify_timeout_destroy(NotifyTimeout* nt)
 
 static gboolean do_exit(gpointer user_data)
 {
-	exit(0);
+	gtk_main_quit();
 	return FALSE;
 }
 


### PR DESCRIPTION
remove exit / replace with gtk_main_quit

mate-notification daemon randomly crashes with Ubuntu noble. The daemon should shut down using gtk_main_quit rather than using exit(0);

[ 7590.265881] mate-notificati[76519]: segfault at 55ac5111c67a ip 00007d1d4fc09d61 sp 00007ffd0bf06698 error 4 in libgobject-2.0.so.0.8000.0[7d1d4fbdc000+37000] likely on  CPU 0 (core 0, socket 0)
[ 7590.265910] Code: 01 00 00 00 4c 89 ce 48 89 e5 e8 da e6 ff ff 5d 85 c0 0f 95 c0 0f b6 c0 c3 f3 0f 1e fa 48 85 ff 74 47 48 8b 07 48 85 c0 74 3f <48> 8b 00 48 3d fc 03 00 00 77 2c 48 8d 15 cd 53 02 00 48 c1 e8 02