### PR TITLE
Add classes for themes

### DIFF
--- a/src/themes/coco/coco-theme.c
+++ b/src/themes/coco/coco-theme.c
@@ -640,11 +640,15 @@ add_notification_action(GtkWindow *nw, const char *text, const char *key,
 			gtk_widget_set_halign (windata->pie_countdown, GTK_ALIGN_END);
 			gtk_widget_show(windata->pie_countdown);
 
+			#if GTK_CHECK_VERSION (4,0,0)
+				gtk_widget_add_css_class (windata->pie_countdown, "countdown");
+			#else
+				gtk_style_context_add_class (gtk_widget_get_style_context (windata->pie_countdown), "countdown");
+			#endif
+
 			gtk_box_pack_end (GTK_BOX (windata->actions_box), windata->pie_countdown, FALSE, TRUE, 0);
-			gtk_widget_set_size_request(windata->pie_countdown,
-						    PIE_WIDTH, PIE_HEIGHT);
-			g_signal_connect(G_OBJECT(windata->pie_countdown), "draw",
-					 G_CALLBACK(countdown_expose_cb), windata);
+			gtk_widget_set_size_request(windata->pie_countdown, PIE_WIDTH, PIE_HEIGHT);
+			g_signal_connect(G_OBJECT(windata->pie_countdown), "draw", G_CALLBACK (countdown_expose_cb), windata);
 		}
 	}
 

--- a/src/themes/coco/coco-theme.c
+++ b/src/themes/coco/coco-theme.c
@@ -418,6 +418,12 @@ create_notification(UrlClickedCb url_clicked)
 	gtk_widget_show(main_vbox);
 	gtk_container_add (GTK_CONTAINER (win), main_vbox);
 
+	#if GTK_CHECK_VERSION (4,0,0)
+		gtk_widget_add_css_class (main_vbox, "notification-box");
+	#else
+		gtk_style_context_add_class (gtk_widget_get_style_context (main_vbox), "notification-box");
+	#endif
+
 	g_signal_connect (G_OBJECT (main_vbox), "draw",
 					 G_CALLBACK (on_draw), windata);
 

--- a/src/themes/coco/coco-theme.c
+++ b/src/themes/coco/coco-theme.c
@@ -420,8 +420,10 @@ create_notification(UrlClickedCb url_clicked)
 
 	#if GTK_CHECK_VERSION (4,0,0)
 		gtk_widget_add_css_class (main_vbox, "notification-box");
+		gtk_widget_add_css_class (main_vbox, "coco-theme");
 	#else
 		gtk_style_context_add_class (gtk_widget_get_style_context (main_vbox), "notification-box");
+		gtk_style_context_add_class (gtk_widget_get_style_context (main_vbox), "coco-theme");
 	#endif
 
 	g_signal_connect (G_OBJECT (main_vbox), "draw",

--- a/src/themes/coco/coco-theme.c
+++ b/src/themes/coco/coco-theme.c
@@ -486,6 +486,13 @@ create_notification(UrlClickedCb url_clicked)
 
 	windata->actions_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 6);
 	gtk_widget_set_halign(windata->actions_box, GTK_ALIGN_END);
+
+	#if GTK_CHECK_VERSION (4,0,0)
+		gtk_widget_add_css_class (windata->actions_box, "actions-box");
+	#else
+		gtk_style_context_add_class (gtk_widget_get_style_context (windata->actions_box), "actions-box");
+	#endif
+
 	gtk_widget_show(windata->actions_box);
 	gtk_box_pack_start(GTK_BOX(vbox), windata->actions_box, FALSE, TRUE, 0);
 

--- a/src/themes/nodoka/nodoka-theme.c
+++ b/src/themes/nodoka/nodoka-theme.c
@@ -773,6 +773,12 @@ create_notification(UrlClickedCb url_clicked)
 	gtk_widget_show(main_vbox);
 	gtk_container_add(GTK_CONTAINER(win), main_vbox);
 
+	#if GTK_CHECK_VERSION (4,0,0)
+		gtk_widget_add_css_class (main_vbox, "notification-box");
+	#else
+		gtk_style_context_add_class (gtk_widget_get_style_context (main_vbox), "notification-box");
+	#endif
+
 	g_signal_connect (G_OBJECT (main_vbox), "draw", G_CALLBACK (on_draw), windata);
 
 	windata->top_spacer = gtk_image_new();

--- a/src/themes/nodoka/nodoka-theme.c
+++ b/src/themes/nodoka/nodoka-theme.c
@@ -879,6 +879,13 @@ create_notification(UrlClickedCb url_clicked)
 
 	windata->actions_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 6);
 	gtk_widget_set_halign (windata->actions_box, GTK_ALIGN_END);
+
+	#if GTK_CHECK_VERSION (4,0,0)
+		gtk_widget_add_css_class (windata->actions_box, "actions-box");
+	#else
+		gtk_style_context_add_class (gtk_widget_get_style_context (windata->actions_box), "actions-box");
+	#endif
+
 	gtk_widget_show(windata->actions_box);
 	gtk_box_pack_start(GTK_BOX(vbox), windata->actions_box, FALSE, TRUE, 0);
 

--- a/src/themes/nodoka/nodoka-theme.c
+++ b/src/themes/nodoka/nodoka-theme.c
@@ -1044,11 +1044,15 @@ add_notification_action(GtkWindow *nw, const char *text, const char *key,
 			gtk_widget_set_halign (windata->pie_countdown, GTK_ALIGN_END);
 			gtk_widget_show(windata->pie_countdown);
 
+			#if GTK_CHECK_VERSION (4,0,0)
+				gtk_widget_add_css_class (windata->pie_countdown, "countdown");
+			#else
+				gtk_style_context_add_class (gtk_widget_get_style_context (windata->pie_countdown), "countdown");
+			#endif
+
 			gtk_box_pack_end (GTK_BOX (windata->actions_box), windata->pie_countdown, FALSE, TRUE, 0);
-			gtk_widget_set_size_request(windata->pie_countdown,
-						    PIE_WIDTH, PIE_HEIGHT);
-			g_signal_connect(G_OBJECT(windata->pie_countdown), "draw",
-					 G_CALLBACK(countdown_expose_cb), windata);
+			gtk_widget_set_size_request(windata->pie_countdown, PIE_WIDTH, PIE_HEIGHT);
+			g_signal_connect(G_OBJECT(windata->pie_countdown), "draw", G_CALLBACK (countdown_expose_cb), windata);
 		}
 	}
 

--- a/src/themes/nodoka/nodoka-theme.c
+++ b/src/themes/nodoka/nodoka-theme.c
@@ -775,8 +775,10 @@ create_notification(UrlClickedCb url_clicked)
 
 	#if GTK_CHECK_VERSION (4,0,0)
 		gtk_widget_add_css_class (main_vbox, "notification-box");
+		gtk_widget_add_css_class (main_vbox, "nodoka-theme");
 	#else
 		gtk_style_context_add_class (gtk_widget_get_style_context (main_vbox), "notification-box");
+		gtk_style_context_add_class (gtk_widget_get_style_context (main_vbox), "nodoka-theme");
 	#endif
 
 	g_signal_connect (G_OBJECT (main_vbox), "draw", G_CALLBACK (on_draw), windata);

--- a/src/themes/slider/theme.c
+++ b/src/themes/slider/theme.c
@@ -364,6 +364,12 @@ GtkWindow* create_notification(UrlClickedCb url_clicked)
 	gtk_container_add(GTK_CONTAINER(win), main_vbox);
 	gtk_container_set_border_width(GTK_CONTAINER(main_vbox), 12);
 
+	#if GTK_CHECK_VERSION (4,0,0)
+		gtk_widget_add_css_class (main_vbox, "notification-box");
+	#else
+		gtk_style_context_add_class (gtk_widget_get_style_context (main_vbox), "notification-box");
+	#endif
+
 	windata->main_hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 	gtk_widget_show(windata->main_hbox);
 	gtk_box_pack_start(GTK_BOX(main_vbox), windata->main_hbox, FALSE, FALSE, 0);

--- a/src/themes/slider/theme.c
+++ b/src/themes/slider/theme.c
@@ -777,11 +777,15 @@ void add_notification_action(GtkWindow* nw, const char* text, const char* key, A
 			gtk_widget_set_valign (windata->pie_countdown, GTK_ALIGN_CENTER);
 			gtk_widget_show(windata->pie_countdown);
 
+			#if GTK_CHECK_VERSION (4,0,0)
+				gtk_widget_add_css_class (windata->pie_countdown, "countdown");
+			#else
+				gtk_style_context_add_class (gtk_widget_get_style_context (windata->pie_countdown), "countdown");
+			#endif
+
 			gtk_box_pack_end (GTK_BOX (windata->actions_box), windata->pie_countdown, FALSE, TRUE, 0);
-			gtk_widget_set_size_request(windata->pie_countdown,
-						    PIE_WIDTH, PIE_HEIGHT);
-			g_signal_connect(G_OBJECT(windata->pie_countdown), "draw",
-					 G_CALLBACK(on_countdown_draw), windata);
+			gtk_widget_set_size_request(windata->pie_countdown, PIE_WIDTH, PIE_HEIGHT);
+			g_signal_connect(G_OBJECT(windata->pie_countdown), "draw", G_CALLBACK (on_countdown_draw), windata);
 		}
 	}
 

--- a/src/themes/slider/theme.c
+++ b/src/themes/slider/theme.c
@@ -449,8 +449,14 @@ GtkWindow* create_notification(UrlClickedCb url_clicked)
 
 	windata->actions_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 6);
 	gtk_widget_set_halign (windata->actions_box, GTK_ALIGN_END);
-	gtk_widget_show(windata->actions_box);
 
+	#if GTK_CHECK_VERSION (4,0,0)
+		gtk_widget_add_css_class (windata->actions_box, "actions-box");
+	#else
+		gtk_style_context_add_class (gtk_widget_get_style_context (windata->actions_box), "actions-box");
+	#endif
+
+	gtk_widget_show(windata->actions_box);
 	gtk_box_pack_start (GTK_BOX (vbox), windata->actions_box, FALSE, TRUE, 0);
 
 	return GTK_WINDOW(win);

--- a/src/themes/slider/theme.c
+++ b/src/themes/slider/theme.c
@@ -366,8 +366,10 @@ GtkWindow* create_notification(UrlClickedCb url_clicked)
 
 	#if GTK_CHECK_VERSION (4,0,0)
 		gtk_widget_add_css_class (main_vbox, "notification-box");
+		gtk_widget_add_css_class (main_vbox, "slider-theme");
 	#else
 		gtk_style_context_add_class (gtk_widget_get_style_context (main_vbox), "notification-box");
+		gtk_style_context_add_class (gtk_widget_get_style_context (main_vbox), "slider-theme");
 	#endif
 
 	windata->main_hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);

--- a/src/themes/standard/theme.c
+++ b/src/themes/standard/theme.c
@@ -696,6 +696,12 @@ GtkWindow* create_notification(UrlClickedCb url_clicked)
 	gtk_container_add (GTK_CONTAINER (win), main_vbox);
 	gtk_container_set_border_width(GTK_CONTAINER(main_vbox), 1);
 
+	#if GTK_CHECK_VERSION (4,0,0)
+		gtk_widget_add_css_class (main_vbox, "notification-box");
+	#else
+		gtk_style_context_add_class (gtk_widget_get_style_context (main_vbox), "notification-box");
+	#endif
+
 	g_signal_connect (G_OBJECT (main_vbox), "draw", G_CALLBACK (on_draw), windata);
 
 	windata->top_spacer = gtk_image_new();

--- a/src/themes/standard/theme.c
+++ b/src/themes/standard/theme.c
@@ -797,6 +797,13 @@ GtkWindow* create_notification(UrlClickedCb url_clicked)
 
 	windata->actions_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 6);
 	gtk_widget_set_halign (windata->actions_box, GTK_ALIGN_END);
+
+	#if GTK_CHECK_VERSION (4,0,0)
+		gtk_widget_add_css_class (windata->actions_box, "actions-box");
+	#else
+		gtk_style_context_add_class (gtk_widget_get_style_context (windata->actions_box), "actions-box");
+	#endif
+
 	gtk_widget_show(windata->actions_box);
 	gtk_box_pack_start(GTK_BOX(vbox), windata->actions_box, FALSE, TRUE, 0);
 

--- a/src/themes/standard/theme.c
+++ b/src/themes/standard/theme.c
@@ -1082,11 +1082,15 @@ void add_notification_action(GtkWindow* nw, const char* text, const char* key, A
 			gtk_widget_set_halign (windata->pie_countdown, GTK_ALIGN_END);
 			gtk_widget_show(windata->pie_countdown);
 
+			#if GTK_CHECK_VERSION (4,0,0)
+				gtk_widget_add_css_class (windata->pie_countdown, "countdown");
+			#else
+				gtk_style_context_add_class (gtk_widget_get_style_context (windata->pie_countdown), "countdown");
+			#endif
+
 			gtk_box_pack_end (GTK_BOX (windata->actions_box), windata->pie_countdown, FALSE, TRUE, 0);
-			gtk_widget_set_size_request(windata->pie_countdown,
-						    PIE_WIDTH, PIE_HEIGHT);
-			g_signal_connect(G_OBJECT(windata->pie_countdown), "draw",
-					 G_CALLBACK(on_countdown_draw), windata);
+			gtk_widget_set_size_request(windata->pie_countdown, PIE_WIDTH, PIE_HEIGHT);
+			g_signal_connect(G_OBJECT(windata->pie_countdown), "draw", G_CALLBACK (on_countdown_draw), windata);
 		}
 	}
 

--- a/src/themes/standard/theme.c
+++ b/src/themes/standard/theme.c
@@ -698,8 +698,10 @@ GtkWindow* create_notification(UrlClickedCb url_clicked)
 
 	#if GTK_CHECK_VERSION (4,0,0)
 		gtk_widget_add_css_class (main_vbox, "notification-box");
+		gtk_widget_add_css_class (main_vbox, "default-theme");
 	#else
 		gtk_style_context_add_class (gtk_widget_get_style_context (main_vbox), "notification-box");
+		gtk_style_context_add_class (gtk_widget_get_style_context (main_vbox), "default-theme");
 	#endif
 
 	g_signal_connect (G_OBJECT (main_vbox), "draw", G_CALLBACK (on_draw), windata);


### PR DESCRIPTION
This is the patch to fix #222.

before:
![notif1](https://github.com/user-attachments/assets/839d974b-cbd3-425c-ac4b-cfc30e66725f)

after:
![notif2](https://github.com/user-attachments/assets/b087fe7e-ffec-4e2e-9892-d675000cbf67)

so, now we can:
```css
.notification-box { border:1px solid orange; background:cyan; }
.notification-box.coco-theme { background:yellow; }
.notification-box .countdown { }
.notification-box .actions-box { border:1px solid black; background-color:white; }
```