### PR TITLE
Update countdown colors for coco theme

### DIFF
--- a/src/themes/coco/coco-theme.c
+++ b/src/themes/coco/coco-theme.c
@@ -292,16 +292,13 @@ configure_event_cb(GtkWidget *nw,
 }
 
 static gboolean
-countdown_expose_cb(GtkWidget *pie,
-					cairo_t *cr,
-					WindowData *windata)
+countdown_expose_cb(GtkWidget *pie, cairo_t *cr, WindowData *windata)
 {
 	cairo_t *cr2;
 	cairo_surface_t *surface;
 	GtkAllocation alloc;
 
-	cairo_set_operator (cr, CAIRO_OPERATOR_SOURCE);
-
+	cairo_set_operator (cr, CAIRO_OPERATOR_OVER);
 	gtk_widget_get_allocation (pie, &alloc);
 
 	surface = cairo_surface_create_similar (cairo_get_target (cr),
@@ -310,13 +307,10 @@ countdown_expose_cb(GtkWidget *pie,
 						alloc.height);
 
 	cr2 = cairo_create (surface);
-
-	cairo_translate (cr2, -alloc.x, -alloc.y);
-	fill_background (pie, windata, cr2);
-	cairo_translate (cr2, alloc.x, alloc.y);
-	draw_pie (pie, windata, cr2);
+	cairo_set_source_rgba (cr2, 0.0, 0.0, 0.0, 0.0); // transparent background color
+	cairo_paint (cr2);
+	draw_pie (pie, windata, cr2); // countdown
 	cairo_fill (cr2);
-
 	cairo_destroy (cr2);
 
 	cairo_save (cr);

--- a/src/themes/coco/coco-theme.c
+++ b/src/themes/coco/coco-theme.c
@@ -172,7 +172,17 @@ draw_pie(GtkWidget *pie, WindowData *windata, cairo_t *cr)
 		return;
 
 	gdouble arc_angle = 1.0 - (gdouble)windata->remaining / (gdouble)windata->timeout;
-	cairo_set_source_rgba (cr, 1.0, 0.4, 0.0, 0.3);
+	
+	// .notification-box .countdown:active { color:#aabbcc; }
+	GdkRGBA colorFront, colorBack;
+	GtkStyleContext *context = gtk_widget_get_style_context (pie);
+	gtk_style_context_get_color (context, GTK_STATE_FLAG_ACTIVE, &colorFront);
+	gtk_style_context_get_color (context, GTK_STATE_FLAG_NORMAL, &colorBack);
+	if (gdk_rgba_equal (&colorFront, &colorBack))
+		cairo_set_source_rgba (cr, 1.0, 0.4, 0.0, 0.3);
+	else
+		cairo_set_source_rgba (cr, colorFront.red, colorFront.green, colorFront.blue, colorFront.alpha);
+	
 	cairo_move_to(cr, PIE_RADIUS, PIE_RADIUS);
 	cairo_arc_negative(cr, PIE_RADIUS, PIE_RADIUS, PIE_RADIUS,
 					-G_PI/2, (-0.25 + arc_angle)*2*G_PI);

--- a/src/themes/nodoka/nodoka-theme.c
+++ b/src/themes/nodoka/nodoka-theme.c
@@ -419,8 +419,12 @@ fill_background(GtkWidget *widget, WindowData *windata, cairo_t *cr)
 static void
 draw_stripe(GtkWidget *widget, WindowData *windata, cairo_t *cr)
 {
+	int stripe_x = 0;
+	if (gtk_widget_get_direction (widget) == GTK_TEXT_DIR_RTL)
+		stripe_x = windata->width - STRIPE_WIDTH - stripe_x;
+
 	cairo_save (cr);
-	cairo_rectangle (cr, 0, 0, STRIPE_WIDTH, windata->height);
+	cairo_rectangle (cr, stripe_x, 0, STRIPE_WIDTH, windata->height);
 	cairo_clip (cr);
 
 	gdouble  color_mult = 1.0;

--- a/src/themes/slider/theme.c
+++ b/src/themes/slider/theme.c
@@ -1,9 +1,8 @@
-/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
- *
+/*
  * Copyright (C) 2006-2007 Christian Hammond <chipx86@chipx86.com>
  * Copyright (C) 2009 Red Hat, Inc.
  * Copyright (C) 2011 Perberos <perberos@gmail.com>
- * Copyright (C) 2012-2021 MATE Developers
+ * Copyright (C) 2012-2025 MATE Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -234,14 +233,10 @@ static void paint_window (GtkWidget  *widget,
 						windata->height);
 
 	cr2 = cairo_create (surface);
-
-	/* transparent background */
 	cairo_rectangle (cr2, 0, 0, windata->width, windata->height);
-	cairo_set_source_rgba (cr2, 0.0, 0.0, 0.0, 0.0);
+	cairo_set_source_rgba (cr2, 0.0, 0.0, 0.0, 0.0); // transparent background color
 	cairo_fill (cr2);
-
 	fill_background (widget, windata, cr2);
-
 	cairo_destroy(cr2);
 
 	cairo_save (cr);
@@ -694,45 +689,37 @@ paint_countdown (GtkWidget  *pie,
 	cairo_t* cr2;
 	cairo_surface_t* surface;
 
-	context = gtk_widget_get_style_context(windata->win);
-
+	// :selected { background-color:#aabbcc; }   or
+	// .notification-box .countdown:selected { background-color:#aabbcc; }
+	context = gtk_widget_get_style_context (pie);
 	gtk_style_context_save (context);
 	gtk_style_context_set_state (context, GTK_STATE_FLAG_SELECTED);
-
 	get_background_color (context, GTK_STATE_FLAG_SELECTED, &bg);
-
 	gtk_style_context_restore (context);
 
 	gtk_widget_get_allocation(pie, &allocation);
-	cairo_set_operator(cr, CAIRO_OPERATOR_SOURCE);
-	surface = cairo_surface_create_similar(cairo_get_target(cr),
-                                           CAIRO_CONTENT_COLOR_ALPHA,
-                                           allocation.width,
-                                           allocation.height);
+	cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
+	surface = cairo_surface_create_similar (cairo_get_target(cr),
+                                             CAIRO_CONTENT_COLOR_ALPHA,
+                                             allocation.width,
+                                             allocation.height);
 
 	cr2 = cairo_create (surface);
-
-	fill_background (pie, windata, cr2);
-
 	if (windata->timeout > 0)
 	{
 		gdouble pct = (gdouble) windata->remaining / (gdouble) windata->timeout;
-
 		gdk_cairo_set_source_rgba (cr2, &bg);
-
 		cairo_move_to (cr2, PIE_RADIUS, PIE_RADIUS);
 		cairo_arc_negative (cr2, PIE_RADIUS, PIE_RADIUS, PIE_RADIUS, -G_PI_2, -(pct * G_PI * 2) - G_PI_2);
 		cairo_line_to (cr2, PIE_RADIUS, PIE_RADIUS);
 		cairo_fill (cr2);
 	}
-
-	cairo_destroy(cr2);
+	cairo_destroy (cr2);
 
 	cairo_save (cr);
 	cairo_set_source_surface (cr, surface, 0, 0);
 	cairo_paint (cr);
 	cairo_restore (cr);
-
 	cairo_surface_destroy(surface);
 }
 
@@ -765,7 +752,7 @@ void add_notification_action(GtkWindow* nw, const char* text, const char* key, A
 
 	g_assert(windata != NULL);
 
-	if (!gtk_widget_get_visible(windata->actions_box))
+	if (gtk_widget_get_visible(windata->actions_box))
 	{
 		gtk_widget_show(windata->actions_box);
 		update_content_hbox_visibility(windata);
@@ -785,7 +772,7 @@ void add_notification_action(GtkWindow* nw, const char* text, const char* key, A
 
 			gtk_box_pack_end (GTK_BOX (windata->actions_box), windata->pie_countdown, FALSE, TRUE, 0);
 			gtk_widget_set_size_request(windata->pie_countdown, PIE_WIDTH, PIE_HEIGHT);
-			g_signal_connect(G_OBJECT(windata->pie_countdown), "draw", G_CALLBACK (on_countdown_draw), windata);
+			g_signal_connect(G_OBJECT(windata->pie_countdown), "draw", G_CALLBACK(on_countdown_draw), windata);
 		}
 	}
 

--- a/src/themes/standard/theme.c
+++ b/src/themes/standard/theme.c
@@ -1,9 +1,8 @@
-/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
- *
+/*
  * Copyright (C) 2006-2007 Christian Hammond <chipx86@chipx86.com>
  * Copyright (C) 2009 Red Hat, Inc.
  * Copyright (C) 2011 Perberos <perberos@gmail.com>
- * Copyright (C) 2012-2021 MATE Developers
+ * Copyright (C) 2012-2025 MATE Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,6 +19,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301, USA.
  */
+
 #include "config.h"
 
 #include <glib/gi18n.h>
@@ -153,7 +153,6 @@ static void fill_background(GtkWidget* widget, WindowData* windata, cairo_t* cr)
 #ifdef ENABLE_GRADIENT_LOOK
     cairo_pattern_t *gradient;
     int              gradient_y;
-
     gradient_y = allocation.height - BOTTOM_GRADIENT_HEIGHT;
 #endif
 
@@ -999,45 +998,37 @@ paint_countdown (GtkWidget  *pie,
     cairo_t* cr2;
     cairo_surface_t* surface;
 
-    context = gtk_widget_get_style_context (windata->win);
-
+    // :selected { background-color:#aabbcc; }   or
+    // .notification-box .countdown:selected { background-color:#aabbcc; }
+    context = gtk_widget_get_style_context (pie);
     gtk_style_context_save (context);
     gtk_style_context_set_state (context, GTK_STATE_FLAG_SELECTED);
-
     get_background_color (context, GTK_STATE_FLAG_SELECTED, &bg);
-
     gtk_style_context_restore (context);
 
     gtk_widget_get_allocation(pie, &alloc);
-    cairo_set_operator(cr, CAIRO_OPERATOR_SOURCE);
+    cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
     surface = cairo_surface_create_similar (cairo_get_target(cr),
                                             CAIRO_CONTENT_COLOR_ALPHA,
                                             alloc.width,
                                             alloc.height);
 
     cr2 = cairo_create (surface);
-
-    fill_background (pie, windata, cr2);
-
     if (windata->timeout > 0)
     {
         gdouble pct = (gdouble) windata->remaining / (gdouble) windata->timeout;
-
         gdk_cairo_set_source_rgba (cr2, &bg);
-
         cairo_move_to (cr2, PIE_RADIUS, PIE_RADIUS);
         cairo_arc_negative (cr2, PIE_RADIUS, PIE_RADIUS, PIE_RADIUS, -G_PI_2, -(pct * G_PI * 2) - G_PI_2);
         cairo_line_to (cr2, PIE_RADIUS, PIE_RADIUS);
         cairo_fill (cr2);
     }
-
-    cairo_destroy(cr2);
+    cairo_destroy (cr2);
 
     cairo_save (cr);
     cairo_set_source_surface (cr, surface, 0, 0);
     cairo_paint (cr);
     cairo_restore (cr);
-
     cairo_surface_destroy(surface);
 }
 
@@ -1080,6 +1071,7 @@ void add_notification_action(GtkWindow* nw, const char* text, const char* key, A
 		if (!windata->pie_countdown) {
 			windata->pie_countdown = gtk_drawing_area_new();
 			gtk_widget_set_halign (windata->pie_countdown, GTK_ALIGN_END);
+			gtk_widget_set_valign (windata->pie_countdown, GTK_ALIGN_CENTER);
 			gtk_widget_show(windata->pie_countdown);
 
 			#if GTK_CHECK_VERSION (4,0,0)
@@ -1090,7 +1082,7 @@ void add_notification_action(GtkWindow* nw, const char* text, const char* key, A
 
 			gtk_box_pack_end (GTK_BOX (windata->actions_box), windata->pie_countdown, FALSE, TRUE, 0);
 			gtk_widget_set_size_request(windata->pie_countdown, PIE_WIDTH, PIE_HEIGHT);
-			g_signal_connect(G_OBJECT(windata->pie_countdown), "draw", G_CALLBACK (on_countdown_draw), windata);
+			g_signal_connect(G_OBJECT(windata->pie_countdown), "draw", G_CALLBACK(on_countdown_draw), windata);
 		}
 	}
 


### PR DESCRIPTION
After PR #232, this PR fix the background color of the countdown.
Made with the help of ChatGPT... but it's not a good dev!

**UPDATED**

without css:
![image](https://github.com/user-attachments/assets/f5d2e9f6-ba70-4ff2-8522-3216485eab63)
![image](https://github.com/user-attachments/assets/4c924b12-afa1-49c9-a97e-447990e5c68e)
![image](https://github.com/user-attachments/assets/6f13085d-2be6-4104-aa92-3498cf138d07)
![image](https://github.com/user-attachments/assets/254b6285-f384-4389-88c1-3d3ad842534a)


with css:
```css
.notification-box .countdown:selected {
        background-color: yellow;
}
```

![image](https://github.com/user-attachments/assets/361351a2-becd-4ea8-bb31-81b1bb8f9d79)
![image](https://github.com/user-attachments/assets/c1777089-7299-476a-b5bc-f320807a0bb6)
![image](https://github.com/user-attachments/assets/46d8149b-15c3-401a-a928-504f2b3f4466)
![image](https://github.com/user-attachments/assets/77797a4b-069e-4f55-bb98-8ae61ad33ce0)

- default color for coco countdown updated
- you can set countdown color for all themes
- countdown for slider theme is restored
- added timeout and button for preview notification

Without this PR and without CSS, for slider and default themes, the color of the countdown come from CSS theme: `:selected { background-color:gray; }`, for nodoka and coco themes, the color is hard-coded.