### PR TITLE
Experiments for transparent notifications without compositor

### DIFF
--- a/src/themes/coco/coco-theme.c
+++ b/src/themes/coco/coco-theme.c
@@ -69,17 +69,13 @@ enum
 	URGENCY_CRITICAL
 };
 
-gboolean theme_check_init (unsigned int major_ver, unsigned int minor_ver,
-			  unsigned int micro_ver);
-void get_theme_info (char **theme_name, char **theme_ver, char **author,
-		    char **homepage);
+gboolean theme_check_init (unsigned int major_ver, unsigned int minor_ver, unsigned int micro_ver);
+void get_theme_info (char **theme_name, char **theme_ver, char **author, char **homepage);
 GtkWindow* create_notification (UrlClickedCb url_clicked);
-void set_notification_text (GtkWindow *nw, const char *summary,
-			   const char *body);
+void set_notification_text (GtkWindow *nw, const char *summary, const char *body);
 void set_notification_icon (GtkWindow *nw, GdkPixbuf *pixbuf);
 void set_notification_arrow (GtkWidget *nw, gboolean visible, int x, int y);
-void add_notification_action (GtkWindow *nw, const char *text, const char *key,
-			     ActionInvokedCb cb);
+void add_notification_action (GtkWindow *nw, const char *text, const char *key, ActionInvokedCb cb);
 void clear_notification_actions (GtkWindow *nw);
 void move_notification (GtkWidget *nw, int x, int y);
 void set_notification_timeout (GtkWindow *nw, glong timeout);
@@ -104,17 +100,14 @@ void notification_tick (GtkWindow *nw, glong remaining);
 
 static void get_background_color (GtkStyleContext *context, GtkStateFlags state, GdkRGBA *color)
 {
-        GdkRGBA *c;
+	g_return_if_fail (color != NULL);
+	g_return_if_fail (GTK_IS_STYLE_CONTEXT (context));
 
-        g_return_if_fail (color != NULL);
-        g_return_if_fail (GTK_IS_STYLE_CONTEXT (context));
+	GdkRGBA *c;
+	gtk_style_context_get (context, state, "background-color", &c, NULL);
 
-        gtk_style_context_get (context, state,
-                               "background-color", &c,
-                               NULL);
-
-        *color = *c;
-        gdk_rgba_free (c);
+	*color = *c;
+	gdk_rgba_free (c);
 }
 
 static gboolean activate_link (GtkLabel *label, const char *url, WindowData *windata)

--- a/src/themes/nodoka/nodoka-theme.c
+++ b/src/themes/nodoka/nodoka-theme.c
@@ -84,17 +84,13 @@ enum
 	URGENCY_CRITICAL
 };
 
-gboolean theme_check_init (unsigned int major_ver, unsigned int minor_ver,
-			  unsigned int micro_ver);
-void get_theme_info (char **theme_name, char **theme_ver, char **author,
-		    char **homepage);
+gboolean theme_check_init (unsigned int major_ver, unsigned int minor_ver, unsigned int micro_ver);
+void get_theme_info (char **theme_name, char **theme_ver, char **author, char **homepage);
 GtkWindow* create_notification (UrlClickedCb url_clicked);
-void set_notification_text (GtkWindow *nw, const char *summary,
-			   const char *body);
+void set_notification_text (GtkWindow *nw, const char *summary, const char *body);
 void set_notification_icon (GtkWindow *nw, GdkPixbuf *pixbuf);
 void set_notification_arrow (GtkWidget *nw, gboolean visible, int x, int y);
-void add_notification_action (GtkWindow *nw, const char *text, const char *key,
-			     ActionInvokedCb cb);
+void add_notification_action (GtkWindow *nw, const char *text, const char *key, ActionInvokedCb cb);
 void clear_notification_actions (GtkWindow *nw);
 void move_notification (GtkWidget *nw, int x, int y);
 void set_notification_timeout (GtkWindow *nw, glong timeout);
@@ -119,17 +115,14 @@ void notification_tick (GtkWindow *nw, glong remaining);
 
 static void get_background_color (GtkStyleContext *context, GtkStateFlags state, GdkRGBA *color)
 {
-        GdkRGBA *c;
+	g_return_if_fail (color != NULL);
+	g_return_if_fail (GTK_IS_STYLE_CONTEXT (context));
 
-        g_return_if_fail (color != NULL);
-        g_return_if_fail (GTK_IS_STYLE_CONTEXT (context));
+	GdkRGBA *c;
+	gtk_style_context_get (context, state, "background-color", &c, NULL);
 
-        gtk_style_context_get (context, state,
-                               "background-color", &c,
-                               NULL);
-
-        *color = *c;
-        gdk_rgba_free (c);
+	*color = *c;
+	gdk_rgba_free (c);
 }
 
 static gboolean activate_link (GtkLabel *label, const char *url, WindowData *windata)

--- a/src/themes/slider/theme.c
+++ b/src/themes/slider/theme.c
@@ -65,17 +65,13 @@ enum {
 	URGENCY_CRITICAL
 };
 
-gboolean theme_check_init (unsigned int major_ver, unsigned int minor_ver,
-			  unsigned int micro_ver);
-void get_theme_info (char **theme_name, char **theme_ver, char **author,
-		    char **homepage);
+gboolean theme_check_init (unsigned int major_ver, unsigned int minor_ver, unsigned int micro_ver);
+void get_theme_info (char **theme_name, char **theme_ver, char **author, char **homepage);
 GtkWindow* create_notification (UrlClickedCb url_clicked);
-void set_notification_text (GtkWindow *nw, const char *summary,
-			   const char *body);
+void set_notification_text (GtkWindow *nw, const char *summary, const char *body);
 void set_notification_icon (GtkWindow *nw, GdkPixbuf *pixbuf);
 void set_notification_arrow (GtkWidget *nw, gboolean visible, int x, int y);
-void add_notification_action (GtkWindow *nw, const char *text, const char *key,
-			     ActionInvokedCb cb);
+void add_notification_action (GtkWindow *nw, const char *text, const char *key, ActionInvokedCb cb);
 void clear_notification_actions (GtkWindow *nw);
 void move_notification (GtkWidget *nw, int x, int y);
 void set_notification_timeout (GtkWindow *nw, glong timeout);
@@ -129,17 +125,14 @@ static void draw_round_rect (cairo_t* cr, gdouble aspect, gdouble x, gdouble y, 
 
 static void get_background_color (GtkStyleContext *context, GtkStateFlags state, GdkRGBA *color)
 {
-    GdkRGBA *c;
+	g_return_if_fail (color != NULL);
+	g_return_if_fail (GTK_IS_STYLE_CONTEXT (context));
 
-    g_return_if_fail (color != NULL);
-    g_return_if_fail (GTK_IS_STYLE_CONTEXT (context));
+	GdkRGBA *c;
+	gtk_style_context_get (context, state, "background-color", &c, NULL);
 
-    gtk_style_context_get (context,
-                           state,
-                           "background-color", &c,
-                           NULL);
-    *color = *c;
-    gdk_rgba_free (c);
+	*color = *c;
+	gdk_rgba_free (c);
 }
 
 static void fill_background (GtkWidget* widget, WindowData* windata, cairo_t* cr)

--- a/src/themes/standard/theme.c
+++ b/src/themes/standard/theme.c
@@ -83,17 +83,13 @@ enum {
 	URGENCY_CRITICAL
 };
 
-gboolean theme_check_init (unsigned int major_ver, unsigned int minor_ver,
-			  unsigned int micro_ver);
-void get_theme_info (char **theme_name, char **theme_ver, char **author,
-		    char **homepage);
+gboolean theme_check_init (unsigned int major_ver, unsigned int minor_ver, unsigned int micro_ver);
+void get_theme_info (char **theme_name, char **theme_ver, char **author, char **homepage);
 GtkWindow* create_notification (UrlClickedCb url_clicked);
-void set_notification_text (GtkWindow *nw, const char *summary,
-			   const char *body);
+void set_notification_text (GtkWindow *nw, const char *summary, const char *body);
 void set_notification_icon (GtkWindow *nw, GdkPixbuf *pixbuf);
 void set_notification_arrow (GtkWidget *nw, gboolean visible, int x, int y);
-void add_notification_action (GtkWindow *nw, const char *text, const char *key,
-			     ActionInvokedCb cb);
+void add_notification_action (GtkWindow *nw, const char *text, const char *key, ActionInvokedCb cb);
 void clear_notification_actions (GtkWindow *nw);
 void move_notification (GtkWidget *nw, int x, int y);
 void set_notification_timeout (GtkWindow *nw, glong timeout);
@@ -123,17 +119,14 @@ void notification_tick (GtkWindow *nw, glong remaining);
 
 static void get_background_color (GtkStyleContext *context, GtkStateFlags state, GdkRGBA *color)
 {
-        GdkRGBA *c;
+	g_return_if_fail (color != NULL);
+	g_return_if_fail (GTK_IS_STYLE_CONTEXT (context));
 
-        g_return_if_fail (color != NULL);
-        g_return_if_fail (GTK_IS_STYLE_CONTEXT (context));
+	GdkRGBA *c;
+	gtk_style_context_get (context, state, "background-color", &c, NULL);
 
-        gtk_style_context_get (context, state,
-                               "background-color", &c,
-                               NULL);
-
-        *color = *c;
-        gdk_rgba_free (c);
+	*color = *c;
+	gdk_rgba_free (c);
 }
 
 static void fill_background (GtkWidget* widget, WindowData* windata, cairo_t* cr)


### PR DESCRIPTION
First I'm a **bad** C developer, this PR contains some experimental changes to do same things for all themes.
Dear Copolit, can you reformat source code?

I would like to fix #98 

![Image](https://github.com/user-attachments/assets/ceb812a0-7514-411a-89b9-c3d207b28c08)

So the problem is `update_shape_region`, in this function there is [gtk_widget_shape_combine_region](url) ([doc](https://docs.gtk.org/gdk3/method.Window.shape_combine_region.html) _Makes pixels in window outside shape_region be transparent, so that the window may be nonrectangular_). I think maybe there is a signal not handled by the window notification... or not.

Current status: maybe no visual changes, and notifications still not always transparent.