### PR TITLE
daemon: report dbus method invocation as handled on error

### DIFF
--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -1371,7 +1371,7 @@ static gboolean notify_daemon_notify_handler(NotifyDaemonNotifications *object, 
 	if (g_hash_table_size (daemon->notification_hash) > MAX_NOTIFICATIONS)
 	{
 		g_dbus_method_invocation_return_error (invocation, notify_daemon_error_quark(), 1, _("Exceeded maximum number of notifications"));
-		return FALSE;
+		return TRUE;
 	}
 
 	/* Grab the settings */
@@ -1676,7 +1676,7 @@ static gboolean notify_daemon_close_notification_handler(NotifyDaemonNotificatio
 	if (id == 0)
 	{
 		g_dbus_method_invocation_return_error (invocation, notify_daemon_error_quark(), 100,  _("%u is not a valid notification ID"), id);
-		return FALSE;
+		return TRUE;
 	}
 	else
 	{


### PR DESCRIPTION
Returning an error for a dbus method is counted as handling a method invocation. Return true in the handler to avoid a use-after-free.

Notably, this avoids the crash (and subsequent wipe of on-screen notifications) that would likely occur when more than MAX_NOTIFICATIONS (20) are displaying at the same time.

this info is taken from the docs in the generated dbus code:
`   * If a signal handler returns %TRUE, it means the signal handler will handle the invocation (e.g. take a reference to @invocation and eventually call notify_daemon_notifications_complete_notify() or e.g. g_dbus_method_invocation_return_error() on it) and no other signal handlers will run. If no signal handler handles the invocation, the %G_DBUS_ERROR_UNKNOWN_METHOD error is returned.
`