### PR TITLE
implement Desktop Notification Specification v1.3

### DIFF
--- a/data/org.mate.NotificationDaemon.gschema.xml.in
+++ b/data/org.mate.NotificationDaemon.gschema.xml.in
@@ -41,5 +41,10 @@
       <summary>Enable persistence</summary>
       <description>Allow notifications to be persistent when requested by applications.</description>
     </key>
+    <key name="show-countdown" type="b">
+      <default>false</default>
+      <summary>Show countdown</summary>
+      <description>Show countdown timer for all non-persistent notifications. If false, only show it for those waiting for user actions.</description>
+    </key>
   </schema>
 </schemalist>

--- a/data/org.mate.NotificationDaemon.gschema.xml.in
+++ b/data/org.mate.NotificationDaemon.gschema.xml.in
@@ -30,5 +30,16 @@
       <summary>Do not disturb</summary>
       <description>When enabled, notifications are not shown.</description>
     </key>
+    <key name="default-timeout" type="i">
+      <range min="0" max="300000"/>
+      <default>7000</default>
+      <summary>Default timeout</summary>
+      <description>Default timeout for notifications in milliseconds. Use 0 for no timeout (persistent).</description>
+    </key>
+    <key name="enable-persistence" type="b">
+      <default>true</default>
+      <summary>Enable persistence</summary>
+      <description>Allow notifications to be persistent when requested by applications.</description>
+    </key>
   </schema>
 </schemalist>

--- a/src/capplet/mate-notification-properties.c
+++ b/src/capplet/mate-notification-properties.c
@@ -45,6 +45,9 @@ typedef struct {
 	GtkWidget* active_checkbox;
 	GtkWidget* dnd_checkbox;
 	GtkWidget* monitor_label;
+	GtkWidget* timeout_spin;
+	GtkWidget* persistence_checkbox;
+	GtkWidget* countdown_checkbox;
 
 	NotifyNotification* preview1;
 	NotifyNotification* preview2;
@@ -494,6 +497,9 @@ static gboolean notification_properties_dialog_init(NotificationAppletDialog* di
 	dialog->active_checkbox = GTK_WIDGET(gtk_builder_get_object(builder, "use_active_check"));
 	dialog->dnd_checkbox = GTK_WIDGET(gtk_builder_get_object(builder, "do_not_disturb_check"));
 	dialog->monitor_label = GTK_WIDGET(gtk_builder_get_object(builder, "monitor_label"));
+	dialog->timeout_spin = GTK_WIDGET(gtk_builder_get_object(builder, "timeout_spin"));
+	dialog->persistence_checkbox = GTK_WIDGET(gtk_builder_get_object(builder, "enable_persistence_check"));
+	dialog->countdown_checkbox = GTK_WIDGET(gtk_builder_get_object(builder, "show_countdown_check"));
 
 	g_object_unref (builder);
 
@@ -504,6 +510,11 @@ static gboolean notification_properties_dialog_init(NotificationAppletDialog* di
 
 	g_settings_bind (dialog->gsettings, GSETTINGS_KEY_USE_ACTIVE_MONITOR, dialog->active_checkbox, "active", G_SETTINGS_BIND_DEFAULT);
 	g_settings_bind (dialog->gsettings, GSETTINGS_KEY_DO_NOT_DISTURB, dialog->dnd_checkbox, "active", G_SETTINGS_BIND_DEFAULT);
+
+	GtkAdjustment *timeout_adjustment = gtk_spin_button_get_adjustment(GTK_SPIN_BUTTON(dialog->timeout_spin));
+	g_settings_bind (dialog->gsettings, GSETTINGS_KEY_DEFAULT_TIMEOUT, timeout_adjustment, "value", G_SETTINGS_BIND_DEFAULT);
+	g_settings_bind (dialog->gsettings, GSETTINGS_KEY_ENABLE_PERSISTENCE, dialog->persistence_checkbox, "active", G_SETTINGS_BIND_DEFAULT);
+	g_settings_bind (dialog->gsettings, GSETTINGS_KEY_SHOW_COUNTDOWN, dialog->countdown_checkbox, "active", G_SETTINGS_BIND_DEFAULT);
 
 	notification_properties_dialog_setup_themes (dialog);
 	notification_properties_dialog_setup_positions (dialog);

--- a/src/capplet/mate-notification-properties.ui
+++ b/src/capplet/mate-notification-properties.ui
@@ -12,6 +12,13 @@
     <property name="can_focus">False</property>
     <property name="icon_name">window-close</property>
   </object>
+  <object class="GtkAdjustment" id="timeout_adjustment">
+    <property name="lower">0</property>
+    <property name="upper">300000</property>
+    <property name="value">7000</property>
+    <property name="step_increment">1000</property>
+    <property name="page_increment">5000</property>
+  </object>
   <object class="GtkDialog" id="dialog">
     <property name="can_focus">False</property>
     <property name="border_width">12</property>
@@ -230,6 +237,119 @@
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkFrame">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label_xalign">0</property>
+            <property name="shadow_type">none</property>
+            <child>
+              <object class="GtkAlignment">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_top">6</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkGrid">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="row_spacing">6</property>
+                        <property name="column_spacing">12</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="label" translatable="yes">_Timeout (ms):</property>
+                            <property name="use_underline">True</property>
+                            <property name="mnemonic_widget">timeout_spin</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkSpinButton" id="timeout_spin">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="adjustment">timeout_adjustment</property>
+                            <property name="climb_rate">1000</property>
+                            <property name="digits">0</property>
+                            <property name="numeric">True</property>
+                            <property name="value">7000</property>
+                            <property name="tooltip_text" translatable="yes">Default timeout for notifications in milliseconds. Use 0 for no timeout (persistent).</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkCheckButton" id="enable_persistence_check">
+                        <property name="label" translatable="yes">Allow Persistent Notifications</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="halign">start</property>
+                        <property name="draw_indicator">True</property>
+                        <property name="tooltip_text" translatable="yes">Allow applications to create notifications that don't disappear automatically</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkCheckButton" id="show_countdown_check">
+                        <property name="label" translatable="yes">Show Countdown Timer</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="halign">start</property>
+                        <property name="draw_indicator">True</property>
+                        <property name="tooltip_text" translatable="yes">Show countdown timer on all timed notifications (not just those with actions)</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child type="label">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Timeout &amp; Behavior</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>

--- a/src/common/constants.h
+++ b/src/common/constants.h
@@ -28,6 +28,9 @@
 #define GSETTINGS_KEY_POPUP_LOCATION     "popup-location"
 #define GSETTINGS_KEY_SOUND_ENABLED      "sound-enabled"
 #define GSETTINGS_KEY_USE_ACTIVE_MONITOR "use-active-monitor"
+#define GSETTINGS_KEY_DEFAULT_TIMEOUT    "default-timeout"
+#define GSETTINGS_KEY_ENABLE_PERSISTENCE "enable-persistence"
+#define GSETTINGS_KEY_SHOW_COUNTDOWN     "show-countdown"
 #define NOTIFICATION_BUS_NAME            "org.freedesktop.Notifications"
 #define NOTIFICATION_BUS_PATH            "/org/freedesktop/Notifications"
 

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -34,8 +34,6 @@
 #define NOTIFY_TYPE_DAEMON (notify_daemon_get_type())
 G_DECLARE_FINAL_TYPE (NotifyDaemon, notify_daemon, NOTIFY, DAEMON, GObject)
 
-#define NOTIFY_DAEMON_DEFAULT_TIMEOUT 7000
-
 enum {
 	URGENCY_LOW,
 	URGENCY_NORMAL,

--- a/src/themes/coco/coco-theme.c
+++ b/src/themes/coco/coco-theme.c
@@ -88,6 +88,7 @@ void move_notification(GtkWidget *nw, int x, int y);
 void set_notification_timeout(GtkWindow *nw, glong timeout);
 void set_notification_hints(GtkWindow *nw, GVariant *hints);
 void notification_tick(GtkWindow *nw, glong remaining);
+static void create_pie_countdown(WindowData* windata);
 
 #define STRIPE_WIDTH  32
 #define WIDTH         300
@@ -658,24 +659,7 @@ add_notification_action(GtkWindow *nw, const char *text, const char *key,
 	if (gtk_widget_get_visible(windata->actions_box))
 	{
 		gtk_widget_show(windata->actions_box);
-
-		/* Don't try to re-add a pie_countdown */
-		if (!windata->pie_countdown) {
-			windata->pie_countdown = gtk_drawing_area_new();
-			gtk_widget_set_halign (windata->pie_countdown, GTK_ALIGN_END);
-			gtk_widget_set_valign (windata->pie_countdown, GTK_ALIGN_CENTER);
-			gtk_widget_show(windata->pie_countdown);
-
-			#if GTK_CHECK_VERSION (4,0,0)
-				gtk_widget_add_css_class (windata->pie_countdown, "countdown");
-			#else
-				gtk_style_context_add_class (gtk_widget_get_style_context (windata->pie_countdown), "countdown");
-			#endif
-
-			gtk_box_pack_end (GTK_BOX (windata->actions_box), windata->pie_countdown, FALSE, TRUE, 0);
-			gtk_widget_set_size_request(windata->pie_countdown, PIE_WIDTH, PIE_HEIGHT);
-			g_signal_connect(G_OBJECT(windata->pie_countdown), "draw", G_CALLBACK (countdown_expose_cb), windata);
-		}
+		create_pie_countdown(windata);
 	}
 
 	if (windata->action_icons) {
@@ -760,6 +744,27 @@ move_notification(GtkWidget *nw, int x, int y)
 /* Hide notification */
 
 /* Set notification timeout */
+static void create_pie_countdown(WindowData* windata)
+{
+	if (windata->pie_countdown != NULL)
+		return; /* Already created */
+
+	windata->pie_countdown = gtk_drawing_area_new();
+	gtk_widget_set_halign (windata->pie_countdown, GTK_ALIGN_END);
+	gtk_widget_set_valign (windata->pie_countdown, GTK_ALIGN_CENTER);
+	gtk_widget_show(windata->pie_countdown);
+
+	#if GTK_CHECK_VERSION (4,0,0)
+		gtk_widget_add_css_class (windata->pie_countdown, "countdown");
+	#else
+		gtk_style_context_add_class (gtk_widget_get_style_context (windata->pie_countdown), "countdown");
+	#endif
+
+	gtk_box_pack_end (GTK_BOX (windata->actions_box), windata->pie_countdown, FALSE, TRUE, 0);
+	gtk_widget_set_size_request(windata->pie_countdown, PIE_WIDTH, PIE_HEIGHT);
+	g_signal_connect(G_OBJECT(windata->pie_countdown), "draw", G_CALLBACK(countdown_expose_cb), windata);
+}
+
 void
 set_notification_timeout(GtkWindow *nw, glong timeout)
 {
@@ -767,6 +772,21 @@ set_notification_timeout(GtkWindow *nw, glong timeout)
 	g_assert(windata != NULL);
 
 	windata->timeout = timeout;
+
+	/* Check if we should show countdown for all timed notifications */
+	if (timeout > 0)
+	{
+		GSettings *gsettings = g_settings_new ("org.mate.NotificationDaemon");
+		gboolean show_countdown = g_settings_get_boolean (gsettings, "show-countdown");
+		g_object_unref (gsettings);
+
+		if (show_countdown)
+		{
+			/* Ensure actions_box is visible for countdown */
+			gtk_widget_show(windata->actions_box);
+			create_pie_countdown(windata);
+		}
+	}
 }
 
 /* Set notification hints */

--- a/src/themes/nodoka/nodoka-theme.c
+++ b/src/themes/nodoka/nodoka-theme.c
@@ -101,6 +101,7 @@ void move_notification(GtkWidget *nw, int x, int y);
 void set_notification_timeout(GtkWindow *nw, glong timeout);
 void set_notification_hints(GtkWindow *nw, GVariant *hints);
 void notification_tick(GtkWindow *nw, glong remaining);
+static void create_pie_countdown(WindowData* windata);
 
 #define STRIPE_WIDTH  32
 #define WIDTH         400
@@ -1064,24 +1065,7 @@ add_notification_action(GtkWindow *nw, const char *text, const char *key,
 	{
 		gtk_widget_show(windata->actions_box);
 		update_content_hbox_visibility(windata);
-
-		/* Don't try to re-add a pie_countdown */
-		if (!windata->pie_countdown) {
-			windata->pie_countdown = gtk_drawing_area_new();
-			gtk_widget_set_halign (windata->pie_countdown, GTK_ALIGN_END);
-			gtk_widget_set_valign (windata->pie_countdown, GTK_ALIGN_CENTER);
-			gtk_widget_show(windata->pie_countdown);
-
-			#if GTK_CHECK_VERSION (4,0,0)
-				gtk_widget_add_css_class (windata->pie_countdown, "countdown");
-			#else
-				gtk_style_context_add_class (gtk_widget_get_style_context (windata->pie_countdown), "countdown");
-			#endif
-
-			gtk_box_pack_end (GTK_BOX (windata->actions_box), windata->pie_countdown, FALSE, TRUE, 0);
-			gtk_widget_set_size_request(windata->pie_countdown, PIE_WIDTH, PIE_HEIGHT);
-			g_signal_connect(G_OBJECT(windata->pie_countdown), "draw", G_CALLBACK(countdown_expose_cb), windata);
-		}
+		create_pie_countdown(windata);
 	}
 
 	if (windata->action_icons) {
@@ -1173,6 +1157,27 @@ move_notification(GtkWidget *nw, int x, int y)
 /* Hide notification */
 
 /* Set notification timeout */
+static void create_pie_countdown(WindowData* windata)
+{
+	if (windata->pie_countdown != NULL)
+		return; /* Already created */
+
+	windata->pie_countdown = gtk_drawing_area_new();
+	gtk_widget_set_halign (windata->pie_countdown, GTK_ALIGN_END);
+	gtk_widget_set_valign (windata->pie_countdown, GTK_ALIGN_CENTER);
+	gtk_widget_show(windata->pie_countdown);
+
+	#if GTK_CHECK_VERSION (4,0,0)
+		gtk_widget_add_css_class (windata->pie_countdown, "countdown");
+	#else
+		gtk_style_context_add_class (gtk_widget_get_style_context (windata->pie_countdown), "countdown");
+	#endif
+
+	gtk_box_pack_end (GTK_BOX (windata->actions_box), windata->pie_countdown, FALSE, TRUE, 0);
+	gtk_widget_set_size_request(windata->pie_countdown, PIE_WIDTH, PIE_HEIGHT);
+	g_signal_connect(G_OBJECT(windata->pie_countdown), "draw", G_CALLBACK(countdown_expose_cb), windata);
+}
+
 void
 set_notification_timeout(GtkWindow *nw, glong timeout)
 {
@@ -1180,6 +1185,22 @@ set_notification_timeout(GtkWindow *nw, glong timeout)
 	g_assert(windata != NULL);
 
 	windata->timeout = timeout;
+
+	/* Check if we should show countdown for all timed notifications */
+	if (timeout > 0)
+	{
+		GSettings *gsettings = g_settings_new ("org.mate.NotificationDaemon");
+		gboolean show_countdown = g_settings_get_boolean (gsettings, "show-countdown");
+		g_object_unref (gsettings);
+
+		if (show_countdown)
+		{
+			/* Ensure actions_box is visible for countdown */
+			gtk_widget_show(windata->actions_box);
+			update_content_hbox_visibility(windata);
+			create_pie_countdown(windata);
+		}
+	}
 }
 
 /* Set notification hints */

--- a/src/themes/slider/theme.c
+++ b/src/themes/slider/theme.c
@@ -83,6 +83,8 @@ void set_notification_timeout(GtkWindow *nw, glong timeout);
 void set_notification_hints(GtkWindow *nw, GVariant *hints);
 void notification_tick(GtkWindow *nw, glong remaining);
 gboolean get_always_stack(GtkWidget* nw);
+static gboolean on_countdown_draw (GtkWidget *widget, cairo_t *cr, WindowData *windata);
+static void create_pie_countdown(WindowData* windata);
 
 #define WIDTH          400
 #define DEFAULT_X0     0
@@ -490,6 +492,22 @@ void set_notification_timeout(GtkWindow *nw, glong timeout)
 	g_assert(windata != NULL);
 
 	windata->timeout = timeout;
+
+	/* Check if we should show countdown for all timed notifications */
+	if (timeout > 0)
+	{
+		GSettings *gsettings = g_settings_new ("org.mate.NotificationDaemon");
+		gboolean show_countdown = g_settings_get_boolean (gsettings, "show-countdown");
+		g_object_unref (gsettings);
+
+		if (show_countdown)
+		{
+			/* Ensure actions_box is visible for countdown */
+			gtk_widget_show(windata->actions_box);
+			update_content_hbox_visibility(windata);
+			create_pie_countdown(windata);
+		}
+	}
 }
 
 void notification_tick(GtkWindow* nw, glong remaining)
@@ -731,6 +749,27 @@ on_countdown_draw (GtkWidget *widget, cairo_t *cr, WindowData *windata)
 	return FALSE;
 }
 
+static void create_pie_countdown(WindowData* windata)
+{
+	if (windata->pie_countdown != NULL)
+		return; /* Already created */
+
+	windata->pie_countdown = gtk_drawing_area_new();
+	gtk_widget_set_halign (windata->pie_countdown, GTK_ALIGN_END);
+	gtk_widget_set_valign (windata->pie_countdown, GTK_ALIGN_CENTER);
+	gtk_widget_show(windata->pie_countdown);
+
+	#if GTK_CHECK_VERSION (4,0,0)
+		gtk_widget_add_css_class (windata->pie_countdown, "countdown");
+	#else
+		gtk_style_context_add_class (gtk_widget_get_style_context (windata->pie_countdown), "countdown");
+	#endif
+
+	gtk_box_pack_end (GTK_BOX (windata->actions_box), windata->pie_countdown, FALSE, TRUE, 0);
+	gtk_widget_set_size_request(windata->pie_countdown, PIE_WIDTH, PIE_HEIGHT);
+	g_signal_connect(G_OBJECT(windata->pie_countdown), "draw", G_CALLBACK(on_countdown_draw), windata);
+}
+
 static void on_action_clicked(GtkWidget* w, GdkEventButton *event, ActionInvokedCb action_cb)
 {
 	GtkWindow* nw = g_object_get_data(G_OBJECT(w), "_nw");
@@ -756,24 +795,7 @@ void add_notification_action(GtkWindow* nw, const char* text, const char* key, A
 	{
 		gtk_widget_show(windata->actions_box);
 		update_content_hbox_visibility(windata);
-
-		/* Don't try to re-add a pie_countdown */
-		if (!windata->pie_countdown) {
-			windata->pie_countdown = gtk_drawing_area_new();
-			gtk_widget_set_halign (windata->pie_countdown, GTK_ALIGN_END);
-			gtk_widget_set_valign (windata->pie_countdown, GTK_ALIGN_CENTER);
-			gtk_widget_show(windata->pie_countdown);
-
-			#if GTK_CHECK_VERSION (4,0,0)
-				gtk_widget_add_css_class (windata->pie_countdown, "countdown");
-			#else
-				gtk_style_context_add_class (gtk_widget_get_style_context (windata->pie_countdown), "countdown");
-			#endif
-
-			gtk_box_pack_end (GTK_BOX (windata->actions_box), windata->pie_countdown, FALSE, TRUE, 0);
-			gtk_widget_set_size_request(windata->pie_countdown, PIE_WIDTH, PIE_HEIGHT);
-			g_signal_connect(G_OBJECT(windata->pie_countdown), "draw", G_CALLBACK(on_countdown_draw), windata);
-		}
+		create_pie_countdown(windata);
 	}
 
 	if (windata->action_icons) {


### PR DESCRIPTION
This implements the [latest freedesktop notification spec](https://specifications.freedesktop.org/notification-spec/latest-single/), specifically:
- allow notifications to persist (resident vs transient)
- provide app icons from their desktop-entry

I also added a few extra features:
- configurable default timeout
- display countdown on all notifications (instead of only those expecting user input)
- expose all those settings in the capplet

Fixes #132 
Fixes #137 
Fixes #138 
Fixes #149 
