### PR TITLE
Notifications history

### DIFF
--- a/src/capplet/Makefile.am
+++ b/src/capplet/Makefile.am
@@ -47,6 +47,8 @@ libmate_notification_applet_la_SOURCES = \
 	mate-notification-applet.c \
 	mate-notification-applet-dbus.h \
 	mate-notification-applet-dbus.c \
+	mate-notification-applet-history.h \
+	mate-notification-applet-history.c \
 	$(NULL)
 
 libmate_notification_applet_la_CFLAGS = \
@@ -68,6 +70,8 @@ mate_notification_applet_SOURCES = \
 	mate-notification-applet.c \
 	mate-notification-applet-dbus.h \
 	mate-notification-applet-dbus.c \
+	mate-notification-applet-history.h \
+	mate-notification-applet-history.c \
 	$(NULL)
 
 mate_notification_applet_CFLAGS = \
@@ -109,6 +113,7 @@ EXTRA_DIST = \
 	mate-notification-applet-menu.xml \
 	mate-notification-properties.ui \
 	mate-notification-applet-dbus.h \
+	mate-notification-applet-history.h \
 	$(NULL)
 
 -include $(top_srcdir)/git.mk

--- a/src/capplet/Makefile.am
+++ b/src/capplet/Makefile.am
@@ -45,6 +45,8 @@ libmate_notification_applet_la_SOURCES = \
 	$(mate_notification_applet_resources_files) \
 	../common/constants.h \
 	mate-notification-applet.c \
+	mate-notification-applet-dbus.h \
+	mate-notification-applet-dbus.c \
 	$(NULL)
 
 libmate_notification_applet_la_CFLAGS = \
@@ -64,6 +66,8 @@ mate_notification_applet_SOURCES = \
 	$(mate_notification_applet_resources_files) \
 	../common/constants.h \
 	mate-notification-applet.c \
+	mate-notification-applet-dbus.h \
+	mate-notification-applet-dbus.c \
 	$(NULL)
 
 mate_notification_applet_CFLAGS = \
@@ -104,6 +108,7 @@ EXTRA_DIST = \
 	$(mate_notification_properties_resources_xml) \
 	mate-notification-applet-menu.xml \
 	mate-notification-properties.ui \
+	mate-notification-applet-dbus.h \
 	$(NULL)
 
 -include $(top_srcdir)/git.mk

--- a/src/capplet/mate-notification-applet-dbus.c
+++ b/src/capplet/mate-notification-applet-dbus.c
@@ -1,0 +1,214 @@
+/* mate-notification-applet-dbus.c - MATE Notification Applet - D-Bus Context
+ *
+ * Copyright (C) 2025 MATE Developers
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301  USA
+ */
+
+#include "config.h"
+
+#include <glib.h>
+#include <gio/gio.h>
+
+#include "mate-notification-applet-dbus.h"
+#include "../common/constants.h"
+
+MateNotificationDBusContext *
+dbus_context_new (void)
+{
+  MateNotificationDBusContext *context = g_new0 (MateNotificationDBusContext, 1);
+  context->daemon_proxy = NULL;
+  context->daemon_available = FALSE;
+  context->watch_id = 0;
+  return context;
+}
+
+void
+dbus_context_free (MateNotificationDBusContext *context)
+{
+  if (context) {
+    dbus_context_disconnect (context);
+    g_free (context);
+  }
+}
+
+gboolean
+dbus_context_connect (MateNotificationDBusContext *context)
+{
+  GError *error = NULL;
+
+  if (!context)
+    return FALSE;
+
+  /* Clean up existing connection */
+  dbus_context_disconnect (context);
+
+  /* Create D-Bus proxy for notification daemon */
+  context->daemon_proxy = g_dbus_proxy_new_for_bus_sync (G_BUS_TYPE_SESSION,
+                                                         G_DBUS_PROXY_FLAGS_NONE,
+                                                         NULL, /* GDBusInterfaceInfo */
+                                                         NOTIFICATION_BUS_NAME,
+                                                         NOTIFICATION_BUS_PATH,
+                                                         "org.freedesktop.Notifications",
+                                                         NULL, /* GCancellable */
+                                                         &error);
+
+  if (error) {
+    g_warning ("Failed to connect to notification daemon: %s", error->message);
+    g_error_free (error);
+    context->daemon_available = FALSE;
+    return FALSE;
+  }
+
+  context->daemon_available = TRUE;
+  return TRUE;
+}
+
+void
+dbus_context_disconnect (MateNotificationDBusContext *context)
+{
+  if (!context)
+    return;
+
+  if (context->daemon_proxy) {
+    g_object_unref (context->daemon_proxy);
+    context->daemon_proxy = NULL;
+  }
+
+  context->daemon_available = FALSE;
+}
+
+gboolean
+dbus_context_is_available (MateNotificationDBusContext *context)
+{
+  return context && context->daemon_available && context->daemon_proxy;
+}
+
+guint
+dbus_context_get_notification_count (MateNotificationDBusContext *context)
+{
+  GVariant *result;
+  GError *error = NULL;
+  guint count = 0;
+
+  if (!dbus_context_is_available (context))
+    return 0;
+
+  result = g_dbus_proxy_call_sync (context->daemon_proxy,
+                                   "GetNotificationCount",
+                                   NULL,
+                                   G_DBUS_CALL_FLAGS_NONE,
+                                   -1, /* timeout */
+                                   NULL, /* GCancellable */
+                                   &error);
+
+  if (error) {
+    g_warning ("Failed to get notification count: %s", error->message);
+    g_error_free (error);
+    context->daemon_available = FALSE;
+  } else if (result) {
+    g_variant_get (result, "(u)", &count);
+    g_variant_unref (result);
+  }
+
+  return count;
+}
+
+gboolean
+dbus_context_clear_notification_history (MateNotificationDBusContext *context)
+{
+  GVariant *result;
+  GError *error = NULL;
+
+  if (!dbus_context_is_available (context))
+    return FALSE;
+
+  result = g_dbus_proxy_call_sync (context->daemon_proxy,
+                                   "ClearNotificationHistory",
+                                   NULL,
+                                   G_DBUS_CALL_FLAGS_NONE,
+                                   -1, /* timeout */
+                                   NULL, /* GCancellable */
+                                   &error);
+
+  if (error) {
+    g_warning ("Failed to clear notification history: %s", error->message);
+    g_error_free (error);
+    return FALSE;
+  }
+
+  if (result) {
+    g_variant_unref (result);
+  }
+
+  return TRUE;
+}
+
+gboolean
+dbus_context_mark_all_notifications_as_read (MateNotificationDBusContext *context)
+{
+  GVariant *result;
+  GError *error = NULL;
+
+  if (!dbus_context_is_available (context))
+    return FALSE;
+
+  result = g_dbus_proxy_call_sync (context->daemon_proxy,
+                                   "MarkAllNotificationsAsRead",
+                                   NULL,
+                                   G_DBUS_CALL_FLAGS_NONE,
+                                   -1, /* timeout */
+                                   NULL, /* GCancellable */
+                                   &error);
+
+  if (error) {
+    g_warning ("Failed to mark all notifications as read: %s", error->message);
+    g_error_free (error);
+    return FALSE;
+  }
+
+  if (result) {
+    g_variant_unref (result);
+  }
+
+  return TRUE;
+}
+
+GVariant *
+dbus_context_get_notification_history (MateNotificationDBusContext *context)
+{
+  GVariant *result;
+  GError *error = NULL;
+
+  if (!dbus_context_is_available (context))
+    return NULL;
+
+  result = g_dbus_proxy_call_sync (context->daemon_proxy,
+                                   "GetNotificationHistory",
+                                   NULL,
+                                   G_DBUS_CALL_FLAGS_NONE,
+                                   -1, /* timeout */
+                                   NULL, /* GCancellable */
+                                   &error);
+
+  if (error) {
+    g_warning ("Failed to get notification history: %s", error->message);
+    g_error_free (error);
+    return NULL;
+  }
+
+  return result; /* Caller owns this reference */
+}

--- a/src/capplet/mate-notification-applet-dbus.h
+++ b/src/capplet/mate-notification-applet-dbus.h
@@ -1,0 +1,52 @@
+/* mate-notification-applet-dbus.h - MATE Notification Applet - D-Bus Context
+ *
+ * Copyright (C) 2025 MATE Developers
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301  USA
+ */
+
+#ifndef __MATE_NOTIFICATION_APPLET_DBUS_H__
+#define __MATE_NOTIFICATION_APPLET_DBUS_H__
+
+#include <gio/gio.h>
+
+G_BEGIN_DECLS
+
+/* D-Bus context structure for notification daemon communication */
+typedef struct {
+  GDBusProxy *daemon_proxy;
+  gboolean    daemon_available;
+  guint       watch_id;
+} MateNotificationDBusContext;
+
+/* Context creation/cleanup */
+MateNotificationDBusContext *dbus_context_new (void);
+void dbus_context_free (MateNotificationDBusContext *context);
+
+/* Connection management */
+gboolean dbus_context_connect (MateNotificationDBusContext *context);
+void dbus_context_disconnect (MateNotificationDBusContext *context);
+gboolean dbus_context_is_available (MateNotificationDBusContext *context);
+
+/* Notification daemon method calls */
+guint dbus_context_get_notification_count (MateNotificationDBusContext *context);
+gboolean dbus_context_clear_notification_history (MateNotificationDBusContext *context);
+gboolean dbus_context_mark_all_notifications_as_read (MateNotificationDBusContext *context);
+GVariant *dbus_context_get_notification_history (MateNotificationDBusContext *context);
+
+G_END_DECLS
+
+#endif /* __MATE_NOTIFICATION_APPLET_DBUS_H__ */

--- a/src/capplet/mate-notification-applet-history.c
+++ b/src/capplet/mate-notification-applet-history.c
@@ -1,0 +1,372 @@
+/* mate-notification-applet.c - MATE Notification Applet - History
+ *
+ * Copyright (C) 2025 MATE Developers
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301  USA
+ */
+
+#include "config.h"
+
+#include <glib/gi18n.h>
+#include <gtk/gtk.h>
+#include <gdk/gdkkeysyms.h>
+
+#include "mate-notification-applet-history.h"
+#include "../common/constants.h"
+
+#define IMAGE_SIZE 48
+
+static GtkWidget *
+create_notification_icon (const gchar *icon_name)
+{
+  GdkPixbuf *pixbuf = NULL;
+  GtkWidget *image;
+
+  if (icon_name && *icon_name) {
+    if (g_path_is_absolute (icon_name)) {
+      pixbuf = gdk_pixbuf_new_from_file_at_scale (icon_name, IMAGE_SIZE, IMAGE_SIZE, TRUE, NULL);
+    } else {
+      GtkIconTheme *theme = gtk_icon_theme_get_default ();
+      pixbuf = gtk_icon_theme_load_icon (theme, icon_name, IMAGE_SIZE, GTK_ICON_LOOKUP_USE_BUILTIN, NULL);
+    }
+  }
+
+  if (pixbuf) {
+    image = gtk_image_new_from_pixbuf (pixbuf);
+    g_object_unref (pixbuf);
+  } else {
+    image = gtk_image_new_from_icon_name ("mate-notification-properties", GTK_ICON_SIZE_DIALOG);
+  }
+
+  gtk_widget_set_valign (image, GTK_ALIGN_CENTER);
+  return image;
+}
+
+static GtkWidget *
+create_popup_window (void)
+{
+  GtkWidget *popup = gtk_window_new (GTK_WINDOW_POPUP);
+  g_object_set (popup,
+                "type-hint", GDK_WINDOW_TYPE_HINT_POPUP_MENU,
+                "skip-taskbar-hint", TRUE,
+                "skip-pager-hint", TRUE,
+                "decorated", FALSE,
+                "resizable", FALSE,
+                NULL);
+  gtk_container_set_border_width (GTK_CONTAINER (popup), 1);
+  return popup;
+}
+
+static void
+popup_destroyed_cb (GtkWidget                      *popup,
+                    MateNotificationHistoryContext *context)
+{
+  (void) popup;
+  context->history_popup = NULL;
+}
+
+static GtkWidget *
+create_notification_row (guint id, const gchar *app_name, const gchar *app_icon,
+                         const gchar *summary, const gchar *body, gint64 timestamp)
+{
+  GtkWidget *row, *hbox, *icon_image, *content_box;
+  GtkWidget *title_label, *body_label, *time_label;
+  GDateTime *dt;
+  gchar *time_str, *markup;
+
+  /* Format timestamp */
+  dt = g_date_time_new_from_unix_local (timestamp / G_TIME_SPAN_SECOND);
+  time_str = g_date_time_format (dt, "%H:%M");
+  g_date_time_unref (dt);
+
+  /* Create row container for the entire notification */
+  row = gtk_list_box_row_new ();
+  hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 12);
+  gtk_container_set_border_width (GTK_CONTAINER (hbox), 6);
+
+  icon_image = create_notification_icon (app_icon);
+
+  content_box = gtk_box_new (GTK_ORIENTATION_VERTICAL, 3);
+
+  /* Title */
+  markup = g_markup_printf_escaped ("<b>%s</b>", summary ? summary : _("(No summary)"));
+  title_label = gtk_label_new (NULL);
+  gtk_label_set_markup (GTK_LABEL (title_label), markup);
+  gtk_widget_set_halign (title_label, GTK_ALIGN_START);
+  gtk_label_set_ellipsize (GTK_LABEL (title_label), PANGO_ELLIPSIZE_END);
+  gtk_label_set_max_width_chars (GTK_LABEL (title_label), 40);
+  g_free (markup);
+
+  /* Body */
+  body_label = NULL;
+  if (body && *body) {
+    body_label = gtk_label_new (NULL);
+    gtk_label_set_markup (GTK_LABEL (body_label), body);
+    gtk_widget_set_halign (body_label, GTK_ALIGN_START);
+    gtk_label_set_ellipsize (GTK_LABEL (body_label), PANGO_ELLIPSIZE_END);
+    gtk_label_set_max_width_chars (GTK_LABEL (body_label), 40);
+
+    /* Set tooltip in case the body overflows */
+    gchar *tooltip_text = g_strdup_printf ("%s\n%s", summary, body);
+    gtk_widget_set_tooltip_text (row, tooltip_text);
+    g_free (tooltip_text);
+  }
+
+  /* Time and app label */
+  markup = g_markup_printf_escaped ("<small>%s - %s</small>",
+                                     app_name ? app_name : _("Unknown"),
+                                     time_str);
+  time_label = gtk_label_new (NULL);
+  gtk_label_set_markup (GTK_LABEL (time_label), markup);
+  gtk_widget_set_halign (time_label, GTK_ALIGN_START);
+  g_free (markup);
+  g_free (time_str);
+
+  /* Pack content box */
+  gtk_box_pack_start (GTK_BOX (content_box), title_label, FALSE, FALSE, 0);
+  if (body_label)
+    gtk_box_pack_start (GTK_BOX (content_box), body_label, FALSE, FALSE, 0);
+  gtk_box_pack_start (GTK_BOX (content_box), time_label, FALSE, FALSE, 0);
+
+  /* Pack horizontal box */
+  gtk_box_pack_start (GTK_BOX (hbox), icon_image, FALSE, FALSE, 0);
+  gtk_box_pack_start (GTK_BOX (hbox), content_box, TRUE, TRUE, 0);
+
+  gtk_container_add (GTK_CONTAINER (row), hbox);
+
+  return row;
+}
+
+static void
+clear_history (GtkWidget                      *button,
+               MateNotificationHistoryContext *context)
+{
+  (void) button;
+
+  /* Clear the notification history */
+  if (dbus_context_clear_notification_history (context->dbus_context)) {
+    /* Trigger count update after clearing */
+    if (context->count_update_callback) {
+      ((void (*)(gpointer)) context->count_update_callback) (context->count_update_user_data);
+    }
+  }
+
+  /* Close the popup */
+  if (context->history_popup) {
+    gtk_widget_destroy (context->history_popup);
+  }
+}
+
+static void
+dnd_toggle_clicked (GtkToggleButton                *toggle,
+                    MateNotificationHistoryContext *context)
+{
+  gboolean active = gtk_toggle_button_get_active (toggle);
+
+  if (context->settings) {
+    g_settings_set_boolean (context->settings, "do-not-disturb", active);
+  }
+}
+
+
+MateNotificationHistoryContext *
+history_context_new (MateNotificationDBusContext *dbus_context,
+                     GtkWidget                   *main_widget,
+                     GCallback                    count_update_callback,
+                     gpointer                     count_update_user_data,
+                     GSettings                   *settings)
+{
+  MateNotificationHistoryContext *context = g_new0 (MateNotificationHistoryContext, 1);
+  context->dbus_context = dbus_context;
+  context->main_widget = main_widget;
+  context->history_popup = NULL;
+  context->count_update_callback = count_update_callback;
+  context->count_update_user_data = count_update_user_data;
+  context->settings = settings;
+  return context;
+}
+
+void
+history_context_free (MateNotificationHistoryContext *context)
+{
+  if (context) {
+    if (context->history_popup) {
+      gtk_widget_destroy (context->history_popup);
+    }
+    g_free (context);
+  }
+}
+
+void
+history_context_update_dbus (MateNotificationHistoryContext *context,
+                             MateNotificationDBusContext    *dbus_context)
+{
+  if (context) {
+    context->dbus_context = dbus_context;
+  }
+}
+
+void
+show_notification_history (MateNotificationHistoryContext *context)
+{
+  GtkWidget *popup;
+  GtkWidget *vbox;
+  GtkWidget *scrolled_window;
+  GtkWidget *list_box;
+  GtkWidget *button_box;
+  GtkWidget *dnd_toggle;
+  GtkWidget *clear_button;
+  GtkWidget *close_button;
+  GVariant *result;
+  GVariantIter *iter;
+  guint id, urgency;
+  gchar *app_name, *app_icon, *summary, *body;
+  gint64 timestamp, closed_timestamp;
+  guint reason;
+  gboolean read;
+  gint x, y;
+  GdkWindow *window;
+
+  if (!dbus_context_is_available (context->dbus_context)) {
+    g_warning ("Cannot show history: daemon not available");
+    return;
+  }
+
+  /* If popup already exists, destroy it (basically toggle off) */
+  if (context->history_popup) {
+    gtk_widget_destroy (context->history_popup);
+    context->history_popup = NULL;
+    return;
+  }
+
+  /* Get notification history from daemon */
+  result = dbus_context_get_notification_history (context->dbus_context);
+
+  if (!result) {
+    g_warning ("Failed to get notification history");
+    return;
+  }
+
+  /* Trigger count update since accessing history marks all as read */
+  if (context->count_update_callback) {
+    ((void (*)(gpointer)) context->count_update_callback) (context->count_update_user_data);
+  }
+
+  popup = create_popup_window ();
+
+  context->history_popup = popup;
+  g_signal_connect (popup, "destroy", G_CALLBACK (popup_destroyed_cb), context);
+
+  /* Create main container */
+  vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
+  gtk_container_set_border_width (GTK_CONTAINER (vbox), 12);
+  gtk_container_add (GTK_CONTAINER (popup), vbox);
+
+  /* Create list box for all notifications */
+  list_box = gtk_list_box_new ();
+  gtk_list_box_set_selection_mode (GTK_LIST_BOX (list_box), GTK_SELECTION_NONE);
+
+  /* Get history data and add to list */
+  gint notification_count = 0;
+  if (result) {
+    g_variant_get (result, "(a(ussssxxuub))", &iter);
+
+    while (g_variant_iter_loop (iter, "(ussssxxuub)",
+                                &id, &app_name, &app_icon, &summary, &body,
+                                &timestamp, &closed_timestamp, &reason, &urgency, &read)) {
+      notification_count++;
+      /* Add each notification as a new row in the list */
+      GtkWidget *row = create_notification_row (id, app_name, app_icon, summary, body, timestamp);
+      gtk_list_box_insert (GTK_LIST_BOX (list_box), row, -1);
+    }
+
+    g_variant_iter_free (iter);
+    g_variant_unref (result);
+  }
+
+  /* Add message if list is empty */
+  if (gtk_list_box_get_row_at_index (GTK_LIST_BOX (list_box), 0) == NULL) {
+    GtkWidget *row = gtk_list_box_row_new ();
+    GtkWidget *label = gtk_label_new (_("No notifications"));
+    gtk_widget_set_sensitive (label, FALSE);
+    gtk_container_set_border_width (GTK_CONTAINER (row), 12);
+    gtk_container_add (GTK_CONTAINER (row), label);
+    gtk_list_box_insert (GTK_LIST_BOX (list_box), row, -1);
+  }
+
+  /* Add this window for the list of notifications */
+  scrolled_window = gtk_scrolled_window_new (NULL, NULL);
+  gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (scrolled_window),
+                                  GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
+
+  /* Calculate to ensure the popup is the right height:
+   * 80% of screen height, with some room for buttons */
+  GdkScreen *screen = gtk_widget_get_screen (context->main_widget);
+  gint max_content_height = (gdk_screen_get_height (screen) * 0.8) - 100;
+
+  gint content_height = 100; /* 100px minimum */
+  if (notification_count > 0)
+    content_height = MIN(notification_count * content_height, max_content_height);
+
+  /* Now force the scrollable window to be the calculated height */
+  gtk_scrolled_window_set_max_content_height (GTK_SCROLLED_WINDOW (scrolled_window), max_content_height);
+  gtk_scrolled_window_set_min_content_height (GTK_SCROLLED_WINDOW (scrolled_window), content_height);
+  gtk_container_add (GTK_CONTAINER (scrolled_window), list_box);
+
+  gtk_box_pack_start (GTK_BOX (vbox), scrolled_window, TRUE, TRUE, 0);
+
+  /* Add a box for action buttons */
+  button_box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 6);
+  gtk_container_set_border_width (GTK_CONTAINER (button_box), 6);
+
+  /* DND toggle first */
+  dnd_toggle = gtk_check_button_new_with_label (_("Do not disturb"));
+  gtk_widget_set_halign (dnd_toggle, GTK_ALIGN_START);
+
+  if (context->settings) {
+    gboolean dnd_enabled = g_settings_get_boolean (context->settings, "do-not-disturb");
+    gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (dnd_toggle), dnd_enabled);
+  }
+
+  g_signal_connect (dnd_toggle, "toggled", G_CALLBACK (dnd_toggle_clicked), context);
+  gtk_box_pack_start (GTK_BOX (button_box), dnd_toggle, FALSE, FALSE, 0);
+
+  /* Spacer to push buttons to the right */
+  GtkWidget *spacer = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
+  gtk_box_pack_start (GTK_BOX (button_box), spacer, TRUE, TRUE, 0);
+
+  /* Then the action buttons */
+  clear_button = gtk_button_new_with_label (_("Clear All"));
+  close_button = gtk_button_new_with_label (_("Close"));
+
+  g_signal_connect (clear_button, "clicked", G_CALLBACK (clear_history), context);
+  g_signal_connect_swapped (close_button, "clicked", G_CALLBACK (gtk_widget_destroy), popup);
+
+  gtk_box_pack_end (GTK_BOX (button_box), close_button, FALSE, FALSE, 0);
+  gtk_box_pack_end (GTK_BOX (button_box), clear_button, FALSE, FALSE, 0);
+  gtk_box_pack_start (GTK_BOX (vbox), button_box, FALSE, FALSE, 0);
+
+  /* Place popup window below the applet */
+  window = gtk_widget_get_window (context->main_widget);
+  if (window) {
+    gdk_window_get_origin (window, &x, &y);
+    gtk_window_move (GTK_WINDOW (popup), x, y + gtk_widget_get_allocated_height (context->main_widget));
+  }
+
+  /* Set popup size based on content (with space for buttons) */
+  gtk_window_set_default_size (GTK_WINDOW (popup), 450, content_height + 100);
+  gtk_widget_show_all (popup);
+}

--- a/src/capplet/mate-notification-applet-history.h
+++ b/src/capplet/mate-notification-applet-history.h
@@ -1,0 +1,59 @@
+/* mate-notification-applet.c - MATE Notification Applet - History
+ *
+ * Copyright (C) 2025 MATE Developers
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301  USA
+ */
+
+#ifndef __MATE_NOTIFICATION_APPLET_HISTORY_H__
+#define __MATE_NOTIFICATION_APPLET_HISTORY_H__
+
+#include <gtk/gtk.h>
+#include <gio/gio.h>
+#include <mate-panel-applet.h>
+
+#include "mate-notification-applet-dbus.h"
+
+G_BEGIN_DECLS
+
+/* History context structure */
+typedef struct {
+  MateNotificationDBusContext *dbus_context;
+  GtkWidget                   *main_widget;
+  GtkWidget                   *history_popup;
+  GCallback                    count_update_callback;
+  gpointer                     count_update_user_data;
+  GSettings                   *settings;
+} MateNotificationHistoryContext;
+
+/* History popup functions */
+void show_notification_history (MateNotificationHistoryContext *context);
+
+/* Context creation/cleanup */
+MateNotificationHistoryContext *history_context_new (MateNotificationDBusContext *dbus_context,
+                                                     GtkWidget                   *main_widget,
+                                                     GCallback                    count_update_callback,
+                                                     gpointer                     count_update_user_data,
+                                                     GSettings                   *settings);
+void history_context_free                           (MateNotificationHistoryContext *context);
+
+/* Context update functions */
+void history_context_update_dbus (MateNotificationHistoryContext *context,
+                                  MateNotificationDBusContext    *dbus_context);
+
+G_END_DECLS
+
+#endif /* __MATE_NOTIFICATION_APPLET_HISTORY_H__ */

--- a/src/capplet/mate-notification-applet-menu.xml
+++ b/src/capplet/mate-notification-applet-menu.xml
@@ -1,3 +1,8 @@
 <menuitem name="DoNotDisturb Item" action="DoNotDisturb" />
+<separator />
+<menuitem name="ShowHistory Item" action="ShowHistory" />
+<menuitem name="ClearHistory Item" action="ClearHistory" />
+<menuitem name="MarkAllRead Item" action="MarkAllRead" />
+<separator />
 <menuitem name="Preferences Item" action="Preferences" />
 <menuitem name="About Item" action="About" />

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -97,6 +97,15 @@ typedef struct {
 #ifdef HAVE_X11
 	Window        src_window_xid;
 #endif /* HAVE_X11 */
+
+	/* Data for notification history */
+	gchar        *app_name;
+	gchar        *app_icon;
+	gchar        *summary;
+	gchar        *body;
+	guint         urgency;
+	gint64        timestamp;
+	NotifydClosedReason close_reason;
 } NotifyTimeout;
 
 typedef struct {
@@ -125,6 +134,11 @@ struct _NotifyDaemon {
 
 	NotifyStackLocation stack_location;
 	NotifyScreen* screen;
+
+	/* Notification history */
+	GQueue *notification_history;
+	guint history_max_items;
+	gboolean history_enabled;
 };
 
 typedef struct {
@@ -139,6 +153,15 @@ static void _emit_closed_signal(GtkWindow* nw, NotifydClosedReason reason);
 static void _action_invoked_cb(GtkWindow* nw, const char* key);
 static NotifyStackLocation get_stack_location_from_string(const gchar *slocation);
 
+static void _init_notification_history(NotifyDaemon* daemon);
+static void _cleanup_notification_history(NotifyDaemon* daemon);
+static void _add_notification_to_history(NotifyDaemon* daemon, guint id,
+					 const gchar *app_name, const gchar *app_icon,
+					 const gchar *summary, const gchar *body, guint urgency,
+					 NotifydClosedReason reason);
+static void _history_item_free(NotificationHistoryItem* item);
+static void _trim_notification_history(NotifyDaemon* daemon);
+
 #ifdef HAVE_X11
 static GdkFilterReturn _notify_x11_filter(GdkXEvent* xevent, GdkEvent* event, NotifyDaemon* daemon);
 static void sync_notification_position(NotifyDaemon* daemon, GtkWindow* nw, Window source);
@@ -149,6 +172,10 @@ static gboolean notify_daemon_notify_handler(NotifyDaemonNotifications *object, 
 static gboolean notify_daemon_close_notification_handler(NotifyDaemonNotifications *object, GDBusMethodInvocation *invocation, guint arg_id, gpointer user_data);
 static gboolean notify_daemon_get_capabilities( NotifyDaemonNotifications *object, GDBusMethodInvocation *invocation);
 static gboolean notify_daemon_get_server_information (NotifyDaemonNotifications *object, GDBusMethodInvocation *invocation, gpointer user_data);
+static gboolean notify_daemon_get_notification_history (NotifyDaemonNotifications *object, GDBusMethodInvocation *invocation, gpointer user_data);
+static gboolean notify_daemon_clear_notification_history (NotifyDaemonNotifications *object, GDBusMethodInvocation *invocation, gpointer user_data);
+static gboolean notify_daemon_get_notification_count (NotifyDaemonNotifications *object, GDBusMethodInvocation *invocation, gpointer user_data);
+static gboolean notify_daemon_mark_all_notifications_as_read (NotifyDaemonNotifications *object, GDBusMethodInvocation *invocation, gpointer user_data);
 
 static GParamSpec *properties[LAST_PROP] = { NULL };
 
@@ -169,6 +196,10 @@ static void bus_acquired_handler_cb (GDBusConnection *connection,
 	g_signal_connect (daemon->skeleton, "handle-close-notification", G_CALLBACK (notify_daemon_close_notification_handler), daemon);
 	g_signal_connect (daemon->skeleton, "handle-get-capabilities", G_CALLBACK (notify_daemon_get_capabilities), daemon);
 	g_signal_connect (daemon->skeleton, "handle-get-server-information", G_CALLBACK (notify_daemon_get_server_information), daemon);
+	g_signal_connect (daemon->skeleton, "handle-get-notification-history", G_CALLBACK (notify_daemon_get_notification_history), daemon);
+	g_signal_connect (daemon->skeleton, "handle-clear-notification-history", G_CALLBACK (notify_daemon_clear_notification_history), daemon);
+	g_signal_connect (daemon->skeleton, "handle-get-notification-count", G_CALLBACK (notify_daemon_get_notification_count), daemon);
+	g_signal_connect (daemon->skeleton, "handle-mark-all-notifications-as-read", G_CALLBACK (notify_daemon_mark_all_notifications_as_read), daemon);
 
 	exported = g_dbus_interface_skeleton_export (G_DBUS_INTERFACE_SKELETON (daemon->skeleton),
 			connection, NOTIFICATION_BUS_PATH, &error);
@@ -262,6 +293,12 @@ static void _notify_timeout_destroy(NotifyTimeout* nt)
 	 */
 	g_signal_handlers_disconnect_by_func(nt->nw, _notification_destroyed_cb, nt->daemon);
 	gtk_widget_destroy(GTK_WIDGET(nt->nw));
+
+	g_free(nt->app_name);
+	g_free(nt->app_icon);
+	g_free(nt->summary);
+	g_free(nt->body);
+
 	g_free(nt);
 }
 
@@ -511,6 +548,8 @@ static void notify_daemon_init(NotifyDaemon* daemon)
 
 	daemon->screen = NULL;
 
+	_init_notification_history(daemon);
+
 	create_screen(daemon);
 
 	daemon->idle_reposition_notify_ids = g_hash_table_new(NULL, NULL);
@@ -583,6 +622,8 @@ static void notify_daemon_finalize(GObject* object)
 
 	destroy_screen(daemon);
 
+	_cleanup_notification_history(daemon);
+
 	if (daemon->bus_name_id > 0)
 	{
 		g_bus_unown_name (daemon->bus_name_id);
@@ -648,6 +689,12 @@ static void _close_notification(NotifyDaemon* daemon, guint id, gboolean hide_no
 
 	if (nt != NULL)
 	{
+		/* Add notification to history right before closing. This way we can access it later (e.g. from the applet) */
+		_add_notification_to_history(daemon, nt->id,
+					     nt->app_name, nt->app_icon,
+					     nt->summary, nt->body, nt->urgency,
+					     reason);
+
 		_emit_closed_signal(nt->nw, reason);
 
 		if (hide_notification)
@@ -834,6 +881,13 @@ static gboolean _is_expired(gpointer key, NotifyTimeout* nt, gboolean* phas_more
 	if (time_span <= 0)
 	{
 		theme_notification_tick(nt->nw, 0);
+
+		/* Add to history before removing (same as in _close_notification, since that function won't be called from here) */
+		_add_notification_to_history(nt->daemon, nt->id,
+					     nt->app_name, nt->app_icon,
+					     nt->summary, nt->body, nt->urgency,
+					     NOTIFYD_CLOSED_EXPIRED);
+
 		_emit_closed_signal(nt->nw, NOTIFYD_CLOSED_EXPIRED);
 		return TRUE;
 	}
@@ -934,7 +988,10 @@ static guint _generate_id(NotifyDaemon* daemon)
 	return id;
 }
 
-static NotifyTimeout* _store_notification(NotifyDaemon* daemon, GtkWindow* nw, int timeout, gboolean resident)
+static NotifyTimeout* _store_notification(NotifyDaemon* daemon, GtkWindow* nw,
+					  int timeout, gboolean resident,
+					  const gchar *app_name, const gchar *app_icon,
+					  const gchar *summary, const gchar *body, guint urgency)
 {
 	NotifyTimeout* nt;
 	guint id = _generate_id(daemon);
@@ -943,6 +1000,15 @@ static NotifyTimeout* _store_notification(NotifyDaemon* daemon, GtkWindow* nw, i
 	nt->id = id;
 	nt->nw = nw;
 	nt->daemon = daemon;
+
+	/* Store notification data for history */
+	nt->app_name = g_strdup(app_name ? app_name : "");
+	nt->app_icon = g_strdup(app_icon ? app_icon : "");
+	nt->summary = g_strdup(summary ? summary : "");
+	nt->body = g_strdup(body ? body : "");
+	nt->urgency = urgency;
+	nt->timestamp = g_get_real_time();
+	nt->close_reason = NOTIFYD_CLOSED_EXPIRED; /* Default to expired, since we don't care about active notifications */
 
 	_calculate_timeout(daemon, nt, timeout, resident);
 
@@ -1376,6 +1442,8 @@ static gboolean notify_daemon_notify_handler(NotifyDaemonNotifications *object, 
 	gboolean transient = FALSE;
 	const gchar *desktop_entry = NULL;
 	const gchar *category = NULL;
+	gchar *resolved_icon = NULL; /* Store resolved icon name in history */
+	guint urgency = URGENCY_NORMAL; /* Default to normal urgency */
 
 #ifdef HAVE_X11
 	Window window_xid = None;
@@ -1392,14 +1460,6 @@ static gboolean notify_daemon_notify_handler(NotifyDaemonNotifications *object, 
 	sound_enabled = g_settings_get_boolean (gsettings, GSETTINGS_KEY_SOUND_ENABLED);
 	do_not_disturb = g_settings_get_boolean (gsettings, GSETTINGS_KEY_DO_NOT_DISTURB);
 	g_object_unref (gsettings);
-
-	/* If we are in do-not-disturb mode, just grab a new id and close the notification */
-	if (do_not_disturb)
-	{
-		return_id = _generate_id (daemon);
-		notify_daemon_notifications_complete_notify (object, invocation, return_id);
-		return TRUE;
-	}
 
 	if (id > 0)
 	{
@@ -1493,6 +1553,19 @@ static gboolean notify_daemon_notify_handler(NotifyDaemonNotifications *object, 
 	// TODO: Use 'category' for future category-based notification settings
 	g_variant_lookup(hints, "category", "s", &category);
 
+	/* Get urgency from hints */
+	if (g_variant_lookup(hints, "urgency", "@*", &data))
+	{
+		if (g_variant_is_of_type (data, G_VARIANT_TYPE_BYTE))
+		{
+			urgency = g_variant_get_byte(data);
+			/* Make sure it's in a valid range */
+			if (urgency > URGENCY_CRITICAL)
+				urgency = URGENCY_CRITICAL;
+		}
+		g_variant_unref(data);
+	}
+
 	/* set up action buttons */
 	for (i = 0; actions[i] != NULL; i += 2)
 	{
@@ -1531,17 +1604,20 @@ static gboolean notify_daemon_notify_handler(NotifyDaemonNotifications *object, 
 	{
 		const char *path = g_variant_get_string (data, NULL);
 		pixbuf = _notify_daemon_pixbuf_from_path (path);
+		resolved_icon = g_strdup(path);
 		g_variant_unref(data);
 	}
 	else if (g_variant_lookup(hints, "image_path", "@s", &data))
 	{
 		const char *path = g_variant_get_string (data, NULL);
 		pixbuf = _notify_daemon_pixbuf_from_path (path);
+		resolved_icon = g_strdup(path);
 		g_variant_unref(data);
 	}
 	else if (*icon != '\0')
 	{
 		pixbuf = _notify_daemon_pixbuf_from_path (icon);
+		resolved_icon = g_strdup(icon);
 	}
 	else if (desktop_entry != NULL && *desktop_entry != '\0')
 	{
@@ -1568,6 +1644,11 @@ static gboolean notify_daemon_notify_handler(NotifyDaemonNotifications *object, 
 		if (icon_name != NULL)
 		{
 			pixbuf = _notify_daemon_pixbuf_from_path (icon_name);
+
+			if (!resolved_icon && (*icon == '\0' || icon == NULL)) {
+				resolved_icon = g_strdup(icon_name);
+			}
+
 			g_free(icon_name);
 		}
 
@@ -1662,7 +1743,10 @@ static gboolean notify_daemon_notify_handler(NotifyDaemonNotifications *object, 
 
 	if (id == 0)
 	{
-		nt = _store_notification (daemon, nw, timeout, resident && !transient);
+		nt = _store_notification (daemon, nw,
+					  timeout, resident && !transient,
+					  app_name, resolved_icon ? resolved_icon : icon,
+					  summary, body, urgency);
 		return_id = nt->id;
 	}
 	else
@@ -1697,11 +1781,14 @@ static gboolean notify_daemon_notify_handler(NotifyDaemonNotifications *object, 
 	 */
 	if (!nt->has_timeout || (!screensaver_active (GTK_WIDGET (nw)) && !fullscreen_window))
 	{
-		theme_show_notification (nw);
-
-		if (sound_file != NULL)
+		if (!do_not_disturb)
 		{
-			sound_play_file (GTK_WIDGET (nw), sound_file);
+			theme_show_notification (nw);
+
+			if (sound_file != NULL)
+			{
+				sound_play_file (GTK_WIDGET (nw), sound_file);
+			}
 		}
 	}
 	else
@@ -1723,6 +1810,10 @@ static gboolean notify_daemon_notify_handler(NotifyDaemonNotifications *object, 
 	if (nt)
 	{
 		_calculate_timeout (daemon, nt, timeout, resident && !transient);
+	}
+
+	if (resolved_icon) {
+		g_free(resolved_icon);
 	}
 
 	notify_daemon_notifications_complete_notify ( object, invocation, return_id);
@@ -1779,6 +1870,156 @@ static gboolean notify_daemon_get_server_information (NotifyDaemonNotifications 
 			PACKAGE_VERSION,
 			"1.3");
 	return TRUE;
+}
+
+static gboolean notify_daemon_get_notification_history (NotifyDaemonNotifications *object, GDBusMethodInvocation *invocation, gpointer user_data)
+{
+	NotifyDaemon *daemon = NOTIFY_DAEMON (user_data);
+	GVariantBuilder *builder;
+	GList *items;
+
+	if (!daemon->notification_history || !daemon->history_enabled) {
+		/* Return empty array if history is disabled or not initialized */
+		builder = g_variant_builder_new (G_VARIANT_TYPE ("a(ussssxxuub)"));
+		notify_daemon_notifications_complete_get_notification_history (object, invocation, g_variant_new ("a(ussssxxuub)", builder));
+		g_variant_builder_unref (builder);
+		return TRUE;
+	}
+
+	builder = g_variant_builder_new (G_VARIANT_TYPE ("a(ussssxxuub)"));
+
+	for (items = g_queue_peek_head_link(daemon->notification_history); items != NULL; items = items->next) {
+		NotificationHistoryItem *item = (NotificationHistoryItem *) items->data;
+
+		/* Mark notification as read when reading through history */
+		item->read = TRUE;
+
+		g_variant_builder_add (builder, "(ussssxxuub)",
+		                       item->id,
+		                       item->app_name,
+		                       item->app_icon,
+		                       item->summary,
+		                       item->body,
+		                       item->timestamp,
+		                       item->closed_timestamp,
+		                       (guint) item->reason,
+		                       item->urgency,
+		                       item->read);
+	}
+
+	notify_daemon_notifications_complete_get_notification_history (object, invocation, g_variant_new ("a(ussssxxuub)", builder));
+	g_variant_builder_unref (builder);
+	return TRUE;
+}
+
+static gboolean notify_daemon_clear_notification_history (NotifyDaemonNotifications *object, GDBusMethodInvocation *invocation, gpointer user_data)
+{
+	NotifyDaemon *daemon = NOTIFY_DAEMON (user_data);
+
+	if (daemon->notification_history) {
+		g_queue_free_full(daemon->notification_history, (GDestroyNotify)_history_item_free);
+		daemon->notification_history = g_queue_new();
+	}
+
+	notify_daemon_notifications_complete_clear_notification_history (object, invocation);
+	return TRUE;
+}
+
+static gboolean notify_daemon_mark_all_notifications_as_read (NotifyDaemonNotifications *object, GDBusMethodInvocation *invocation, gpointer user_data)
+{
+	NotifyDaemon *daemon = NOTIFY_DAEMON (user_data);
+	GList *items;
+
+	if (daemon->notification_history && daemon->history_enabled) {
+		for (items = g_queue_peek_head_link(daemon->notification_history); items != NULL; items = items->next) {
+			NotificationHistoryItem *item = (NotificationHistoryItem *) items->data;
+			item->read = TRUE;
+		}
+	}
+
+	notify_daemon_notifications_complete_mark_all_notifications_as_read (object, invocation);
+	return TRUE;
+}
+
+static gboolean notify_daemon_get_notification_count (NotifyDaemonNotifications *object, GDBusMethodInvocation *invocation, gpointer user_data)
+{
+	NotifyDaemon *daemon = NOTIFY_DAEMON (user_data);
+	guint count = 0;
+	GList *items;
+
+	if (daemon->notification_history && daemon->history_enabled) {
+		/* Count unread notifications */
+		for (items = g_queue_peek_head_link(daemon->notification_history); items != NULL; items = items->next) {
+			NotificationHistoryItem *item = (NotificationHistoryItem *) items->data;
+			if (!item->read) {
+				count++;
+			}
+		}
+	}
+
+	notify_daemon_notifications_complete_get_notification_count (object, invocation, count);
+	return TRUE;
+}
+
+static void _history_item_free(NotificationHistoryItem* item)
+{
+	if (item) {
+		g_free(item->app_name);
+		g_free(item->app_icon);
+		g_free(item->summary);
+		g_free(item->body);
+		g_free(item);
+	}
+}
+
+static void _init_notification_history(NotifyDaemon* daemon)
+{
+	daemon->notification_history = g_queue_new();
+	daemon->history_max_items = 100; /* Default max items */
+	daemon->history_enabled = TRUE;  /* Default enabled */
+}
+
+static void _cleanup_notification_history(NotifyDaemon* daemon)
+{
+	if (daemon->notification_history) {
+		g_queue_free_full(daemon->notification_history, (GDestroyNotify)_history_item_free);
+		daemon->notification_history = NULL;
+	}
+}
+
+static void _trim_notification_history(NotifyDaemon* daemon)
+{
+	if (!daemon->notification_history)
+		return;
+
+	while (g_queue_get_length(daemon->notification_history) > daemon->history_max_items) {
+		NotificationHistoryItem* item = g_queue_pop_tail(daemon->notification_history);
+		_history_item_free(item);
+	}
+}
+
+static void _add_notification_to_history(NotifyDaemon* daemon, guint id,
+					 const gchar *app_name, const gchar *app_icon,
+					 const gchar *summary, const gchar *body, guint urgency,
+					 NotifydClosedReason reason)
+{
+	if (!daemon->history_enabled || !daemon->notification_history)
+		return;
+
+	NotificationHistoryItem* item = g_new0(NotificationHistoryItem, 1);
+	item->id = id;
+	item->app_name = g_strdup(app_name ? app_name : "");
+	item->app_icon = g_strdup(app_icon ? app_icon : "");
+	item->summary = g_strdup(summary ? summary : "");
+	item->body = g_strdup(body ? body : "");
+	item->timestamp = g_get_real_time();
+	item->closed_timestamp = g_get_real_time();
+	item->reason = reason;
+	item->urgency = urgency;
+	item->read = FALSE; /* Mark as unread initially */
+
+	g_queue_push_head(daemon->notification_history, item);
+	_trim_notification_history(daemon);
 }
 
 NotifyDaemon* notify_daemon_new (gboolean replace, gboolean idle_exit)

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -47,6 +47,19 @@ typedef enum {
 	NOTIFYD_CLOSED_RESERVED = 4
 } NotifydClosedReason;
 
+typedef struct {
+	guint id;                   /* Original notification ID */
+	gchar *app_name;            /* Application name */
+	gchar *app_icon;            /* Icon name/path */
+	gchar *summary;             /* Notification title */
+	gchar *body;                /* Notification body */
+	gint64 timestamp;           /* When notification appeared */
+	gint64 closed_timestamp;    /* When notification was closed */
+	NotifydClosedReason reason; /* How it was closed */
+	guint urgency;              /* Low/Normal/Critical */
+	gboolean read;              /* Has user seen this in history */
+} NotificationHistoryItem;
+
 G_BEGIN_DECLS
 
 NotifyDaemon*     notify_daemon_new        (gboolean replace,

--- a/src/daemon/notificationdaemon.xml
+++ b/src/daemon/notificationdaemon.xml
@@ -30,6 +30,20 @@
       <arg type="s" name="return_spec_version" direction="out"/>
     </method>
 
+    <method name="GetNotificationHistory">
+      <arg type="a(ussssxxuub)" name="history_items" direction="out"/>
+    </method>
+
+    <method name="ClearNotificationHistory">
+    </method>
+
+    <method name="GetNotificationCount">
+      <arg type="u" name="count" direction="out"/>
+    </method>
+
+    <method name="MarkAllNotificationsAsRead">
+    </method>
+
     <signal name="ActionInvoked">
 	    <arg type="u" name="id" />
 	    <arg type="s" name="action_key" />


### PR DESCRIPTION
This is a large PR and I've tried splitting things into several manageable (but atomic) commits, and keep things in separate files where it makes sense.

This adds a whole history tracking system through D-Bus, with notifications accessible through a popup. Here are some screenshots of the thing:

Unread notification count badge:
<img width="65" height="64" alt="Screenshot at 2025-08-28 11-23-46" src="https://github.com/user-attachments/assets/f90bfbce-e93d-4a6c-8cd5-8caa060645c2" />

Tooltip with status and unread count:
<img width="380" height="137" alt="Screenshot at 2025-08-28 10-54-03" src="https://github.com/user-attachments/assets/00f8831e-5b99-4275-ac88-21a3698f0534" />

Empty notifications:
<img width="910" height="469" alt="Screenshot at 2025-08-28 10-52-35" src="https://github.com/user-attachments/assets/45c69b4b-844d-4602-a319-1c86dbd627fb" />

Some notifications in the buffer:
<img width="909" height="870" alt="Screenshot at 2025-08-28 10-53-20" src="https://github.com/user-attachments/assets/7cdc6cf9-8ad7-458c-a6ff-01076d95a905" />

Additional menu items:
<img width="374" height="601" alt="Screenshot at 2025-08-28 10-54-55" src="https://github.com/user-attachments/assets/f0a57a75-242d-4fd9-9ec1-cdc90a0204b0" />