### PR TITLE
daemon: Bump libwnck to 43.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -179,7 +179,7 @@ fi
 dnl Check if we have the X development libraries
 have_x11=no
 if test "x$enable_x11" != "xno"; then
-	x11_pkg_modules="libwnck-3.0, x11"
+	x11_pkg_modules="libwnck-3.0 >= 43.0, x11"
 	PKG_CHECK_MODULES(NOTIFICATION_DAEMON_X11, $x11_pkg_modules, [
 		have_x11=yes
 		AC_DEFINE(HAVE_X11, 1, [Have the X11 development library])


### PR DESCRIPTION
Recent versions of libwnck introduced a WnckHandler object to be used as the main entry point into the library.