### PR TITLE
daemon: Improve icon selection in notifications

### DIFF
--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -32,6 +32,8 @@
 #include <glib/gi18n.h>
 #include <glib.h>
 #include <glib-object.h>
+#include <gio/gio.h>
+#include <gio/gdesktopappinfo.h>
 #include <gtk/gtk.h>
 
 #ifdef HAVE_X11
@@ -1702,6 +1704,40 @@ static gboolean notify_daemon_notify_handler(NotifyDaemonNotifications *object, 
 
 		g_key_file_free(key_file);
 		g_free(desktop_file);
+	}
+	else if (app_name != NULL && *app_name != '\0')
+	{
+		/* Fallback: Try to find icon from desktop key file based on the app_name */
+		gchar *desktop_key = g_ascii_strdown(app_name, -1);
+		for (gchar *p = desktop_key; *p != '\0'; p++) {
+			if (*p == ' ') *p = '-';
+		}
+		gchar *desktop_id = g_strdup_printf("%s.desktop", desktop_key);
+		GDesktopAppInfo *app_info = g_desktop_app_info_new(desktop_id);
+
+		if (app_info != NULL)
+		{
+			GIcon *gicon = g_app_info_get_icon(G_APP_INFO(app_info));
+			if (gicon != NULL)
+			{
+				GtkIconInfo *icon_info = gtk_icon_theme_lookup_by_gicon(gtk_icon_theme_get_default(),
+											gicon,
+											IMAGE_SIZE,
+											GTK_ICON_LOOKUP_USE_BUILTIN);
+				if (icon_info != NULL)
+				{
+					pixbuf = gtk_icon_info_load_icon(icon_info, NULL);
+					if (pixbuf != NULL && !resolved_icon && (*icon == '\0' || icon == NULL)) {
+						resolved_icon = g_strdup(g_icon_to_string(gicon));
+					}
+					g_object_unref(icon_info);
+				}
+			}
+			g_object_unref(app_info);
+		}
+
+		g_free(desktop_id);
+		g_free(desktop_key);
 	}
 	else if (g_variant_lookup(hints, "icon_data", "@(iiibiiay)", &data))
 	{

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -1640,36 +1640,47 @@ static gboolean notify_daemon_notify_handler(NotifyDaemonNotifications *object, 
 	 * 3. icon (which falls back to the desktop entry)
 	 * 4. icon_data (for backward compatibility)
 	 */
-	if (g_variant_lookup(hints, "image-data", "@(iiibiiay)", &data))
+	if (pixbuf == NULL && g_variant_lookup(hints, "image-data", "@(iiibiiay)", &data))
 	{
 		pixbuf = _notify_daemon_pixbuf_from_data_hint (data);
 		g_variant_unref(data);
 	}
-	else if (g_variant_lookup(hints, "image_data", "@(iiibiiay)", &data))
+
+	if (pixbuf == NULL && g_variant_lookup(hints, "image_data", "@(iiibiiay)", &data))
 	{
 		pixbuf = _notify_daemon_pixbuf_from_data_hint (data);
 		g_variant_unref(data);
 	}
-	else if (g_variant_lookup(hints, "image-path", "@s", &data))
+
+	if (pixbuf == NULL && g_variant_lookup(hints, "image-path", "@s", &data))
 	{
 		const char *path = g_variant_get_string (data, NULL);
 		pixbuf = _notify_daemon_pixbuf_from_path (path);
-		resolved_icon = g_strdup(path);
+		if (pixbuf != NULL) {
+			resolved_icon = g_strdup(path);
+		}
 		g_variant_unref(data);
 	}
-	else if (g_variant_lookup(hints, "image_path", "@s", &data))
+
+	if (pixbuf == NULL && g_variant_lookup(hints, "image_path", "@s", &data))
 	{
 		const char *path = g_variant_get_string (data, NULL);
 		pixbuf = _notify_daemon_pixbuf_from_path (path);
-		resolved_icon = g_strdup(path);
+		if (pixbuf != NULL) {
+			resolved_icon = g_strdup(path);
+		}
 		g_variant_unref(data);
 	}
-	else if (*icon != '\0')
+
+	if (pixbuf == NULL && icon != NULL && *icon != '\0')
 	{
 		pixbuf = _notify_daemon_pixbuf_from_path (icon);
-		resolved_icon = g_strdup(icon);
+		if (pixbuf != NULL) {
+			resolved_icon = g_strdup(icon);
+		}
 	}
-	else if (desktop_entry != NULL && *desktop_entry != '\0')
+
+	if (pixbuf == NULL && desktop_entry != NULL && *desktop_entry != '\0')
 	{
 		/* Use desktop-entry to resolve application icon as fallback */
 		gchar *desktop_file = g_strdup_printf("%s.desktop", desktop_entry);
@@ -1695,7 +1706,7 @@ static gboolean notify_daemon_notify_handler(NotifyDaemonNotifications *object, 
 		{
 			pixbuf = _notify_daemon_pixbuf_from_path (icon_name);
 
-			if (!resolved_icon && (*icon == '\0' || icon == NULL)) {
+			if (pixbuf != NULL && !resolved_icon) {
 				resolved_icon = g_strdup(icon_name);
 			}
 
@@ -1705,9 +1716,10 @@ static gboolean notify_daemon_notify_handler(NotifyDaemonNotifications *object, 
 		g_key_file_free(key_file);
 		g_free(desktop_file);
 	}
-	else if (app_name != NULL && *app_name != '\0')
+
+	if (pixbuf == NULL && app_name != NULL && *app_name != '\0')
 	{
-		/* Fallback: Try to find icon from desktop key file based on the app_name */
+		/* Fallback: Try to derive desktop entry from app_name */
 		gchar *desktop_key = g_ascii_strdown(app_name, -1);
 		for (gchar *p = desktop_key; *p != '\0'; p++) {
 			if (*p == ' ') *p = '-';
@@ -1727,7 +1739,7 @@ static gboolean notify_daemon_notify_handler(NotifyDaemonNotifications *object, 
 				if (icon_info != NULL)
 				{
 					pixbuf = gtk_icon_info_load_icon(icon_info, NULL);
-					if (pixbuf != NULL && !resolved_icon && (*icon == '\0' || icon == NULL)) {
+					if (pixbuf != NULL && !resolved_icon) {
 						resolved_icon = g_strdup(g_icon_to_string(gicon));
 					}
 					g_object_unref(icon_info);
@@ -1739,7 +1751,8 @@ static gboolean notify_daemon_notify_handler(NotifyDaemonNotifications *object, 
 		g_free(desktop_id);
 		g_free(desktop_key);
 	}
-	else if (g_variant_lookup(hints, "icon_data", "@(iiibiiay)", &data))
+
+	if (pixbuf == NULL && g_variant_lookup(hints, "icon_data", "@(iiibiiay)", &data))
 	{
 		g_warning("\"icon_data\" hint is deprecated, please use \"image_data\" instead");
 		pixbuf = _notify_daemon_pixbuf_from_data_hint (data);


### PR DESCRIPTION
These two commits improve how the notifications daemon selects what icon to display on the notifications. First by adding an app-name fallback so that it can always default to the icon of the application that emitted the notification, and second by improving the selection mechanism so that if one fails, it moves on to the next one, in the [priority order defined in the notification spec](https://specifications.freedesktop.org/notification/latest-single/#id-1.6.4).