### PR TITLE
Add version flag to daemon and properties dialog

### DIFF
--- a/src/capplet/mate-notification-properties.c
+++ b/src/capplet/mate-notification-properties.c
@@ -565,6 +565,14 @@ static void notification_properties_dialog_finalize(NotificationAppletDialog* di
 int main(int argc, char** argv)
 {
 	NotificationAppletDialog *dialog;
+	static gboolean show_version = FALSE;
+	GOptionContext *option_context;
+	GError *error = NULL;
+
+	static GOptionEntry option_entries[] = {
+		{ "version", 'v', 0, G_OPTION_ARG_NONE, &show_version, N_("Version of this application"), NULL },
+		{ NULL }
+	};
 
 #ifdef ENABLE_NLS
 	bindtextdomain(GETTEXT_PACKAGE, NOTIFICATION_LOCALEDIR);
@@ -572,7 +580,25 @@ int main(int argc, char** argv)
 	textdomain(GETTEXT_PACKAGE);
 #endif /* ENABLE_NLS */
 
-	gtk_init(&argc, &argv);
+	option_context = g_option_context_new (NULL);
+	g_option_context_add_main_entries (option_context, option_entries, GETTEXT_PACKAGE);
+	g_option_context_add_group (option_context, gtk_get_option_group (TRUE));
+
+	if (!g_option_context_parse (option_context, &argc, &argv, &error))
+	{
+		g_warning ("%s", error->message);
+		g_error_free (error);
+		g_option_context_free (option_context);
+		return 1;
+	}
+
+	g_option_context_free (option_context);
+
+	if (show_version)
+	{
+		g_print ("%s %s\n", PACKAGE, VERSION);
+		return 0;
+	}
 
 	notify_init("mate-notification-properties");
 

--- a/src/daemon/mnd-daemon.c
+++ b/src/daemon/mnd-daemon.c
@@ -32,6 +32,7 @@
 static gboolean debug = FALSE;
 static gboolean replace = FALSE;
 static gboolean idle_exit = FALSE;
+static gboolean show_version = FALSE;
 
 static GOptionEntry entries[] =
 {
@@ -51,6 +52,12 @@ static GOptionEntry entries[] =
 		"idle-exit", 'i', G_OPTION_FLAG_NONE,
 		G_OPTION_ARG_NONE, &idle_exit,
 		"Auto-exit when idle, useful if run through D-Bus activation",
+		NULL
+	},
+	{
+		"version", 'v', G_OPTION_FLAG_NONE,
+		G_OPTION_ARG_NONE, &show_version,
+		"Version of this application",
 		NULL
 	},
 	{
@@ -101,6 +108,12 @@ int main (int argc, char *argv[])
 
 	if (!parse_arguments (&argc, &argv))
 		return EXIT_FAILURE;
+
+	if (show_version)
+	{
+		g_print ("%s %s\n", PACKAGE, VERSION);
+		return EXIT_SUCCESS;
+	}
 
 	daemon = notify_daemon_new (replace, idle_exit);
 


### PR DESCRIPTION
The mate-notification-properties binary had no command-line option parsing, making it hard to know the installed version.

This adds the version flag to both mate-notification-properties and mate-notification-daemon.

```
$ mate-notification-properties --version
mate-notification-daemon 1.29.0

$ /usr/libexec/mate-notification-daemon --version
mate-notification-daemon 1.29.0

$ mate-notification-properties --help
Usage:
  mate-notification-properties [OPTION…]

Help Options:
  -h, --help               Show help options
  --help-all               Show all help options
  --help-gtk               Show GTK+ Options

Application Options:
  -v, --version            Version of this application
  --display=DISPLAY        X display to use

```

Fixes #228