### PR TITLE
themes: fix rounded corners not showing without compositor

### DIFF
--- a/src/themes/coco/coco-theme.c
+++ b/src/themes/coco/coco-theme.c
@@ -249,6 +249,7 @@ update_shape_region (cairo_surface_t *surface,
 
 	windata->last_width = windata->width;
 	windata->last_height = windata->height;
+	gtk_widget_queue_draw (GTK_WIDGET (windata->win));
 }
 
 static void

--- a/src/themes/nodoka/nodoka-theme.c
+++ b/src/themes/nodoka/nodoka-theme.c
@@ -594,6 +594,7 @@ update_shape_region (cairo_surface_t *surface,
 
 	windata->last_width = windata->width;
 	windata->last_height = windata->height;
+	gtk_widget_queue_draw (GTK_WIDGET (windata->win));
 }
 
 static void

--- a/src/themes/slider/theme.c
+++ b/src/themes/slider/theme.c
@@ -211,6 +211,7 @@ update_shape_region (cairo_surface_t *surface,
 
 	windata->last_width = windata->width;
 	windata->last_height = windata->height;
+	gtk_widget_queue_draw (GTK_WIDGET (windata->win));
 }
 
 static void paint_window (GtkWidget  *widget,


### PR DESCRIPTION
When compositing is disabled, notifications have a rounded shape mask applied but it's not redrawn. This change queues a redraw after applying the shape region so the notification shows rounded corners.

Fixes #98