### PR TITLE
daemon: Handle notification display based on urgency

### DIFF
--- a/data/org.mate.NotificationDaemon.gschema.xml.in
+++ b/data/org.mate.NotificationDaemon.gschema.xml.in
@@ -51,5 +51,10 @@
       <summary>Enable notification history</summary>
       <description>When enabled, notifications are stored in history for later viewing. When disabled, no notification history is kept for privacy. Note: This only controls MATE's notification daemon storage; other applications may still have access to notifications through system logs or other means.</description>
     </key>
+    <key name="force-display" type="b">
+      <default>false</default>
+      <summary>Force display all notifications</summary>
+      <description>When enabled, all notifications are shown regardless of urgency, fullscreen, or screensaver state. Do Not Disturb still takes precedence.</description>
+    </key>
   </schema>
 </schemalist>

--- a/src/capplet/mate-notification-properties.c
+++ b/src/capplet/mate-notification-properties.c
@@ -49,6 +49,7 @@ typedef struct {
 	GtkWidget* timeout_spin;
 	GtkWidget* persistence_checkbox;
 	GtkWidget* countdown_checkbox;
+	GtkWidget* force_display_checkbox;
 
 	NotifyNotification* preview1;
 	NotifyNotification* preview2;
@@ -502,6 +503,7 @@ static gboolean notification_properties_dialog_init(NotificationAppletDialog* di
 	dialog->timeout_spin = GTK_WIDGET(gtk_builder_get_object(builder, "timeout_spin"));
 	dialog->persistence_checkbox = GTK_WIDGET(gtk_builder_get_object(builder, "enable_persistence_check"));
 	dialog->countdown_checkbox = GTK_WIDGET(gtk_builder_get_object(builder, "show_countdown_check"));
+	dialog->force_display_checkbox = GTK_WIDGET(gtk_builder_get_object(builder, "force_display_check"));
 
 	g_object_unref (builder);
 
@@ -518,6 +520,7 @@ static gboolean notification_properties_dialog_init(NotificationAppletDialog* di
 	g_settings_bind (dialog->gsettings, GSETTINGS_KEY_DEFAULT_TIMEOUT, timeout_adjustment, "value", G_SETTINGS_BIND_DEFAULT);
 	g_settings_bind (dialog->gsettings, GSETTINGS_KEY_ENABLE_PERSISTENCE, dialog->persistence_checkbox, "active", G_SETTINGS_BIND_DEFAULT);
 	g_settings_bind (dialog->gsettings, GSETTINGS_KEY_SHOW_COUNTDOWN, dialog->countdown_checkbox, "active", G_SETTINGS_BIND_DEFAULT);
+	g_settings_bind (dialog->gsettings, GSETTINGS_KEY_FORCE_DISPLAY, dialog->force_display_checkbox, "active", G_SETTINGS_BIND_DEFAULT);
 
 	notification_properties_dialog_setup_themes (dialog);
 	notification_properties_dialog_setup_positions (dialog);

--- a/src/capplet/mate-notification-properties.ui
+++ b/src/capplet/mate-notification-properties.ui
@@ -347,6 +347,22 @@
                         <property name="position">2</property>
                       </packing>
                     </child>
+                    <child>
+                      <object class="GtkCheckButton" id="force_display_check">
+                        <property name="label" translatable="yes">Force Display All Notifications</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="halign">start</property>
+                        <property name="draw_indicator">True</property>
+                        <property name="tooltip_text" translatable="yes">Show all notifications regardless of urgency, fullscreen, or screensaver state. Do Not Disturb still takes precedence.</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">3</property>
+                      </packing>
+                    </child>
                   </object>
                 </child>
               </object>

--- a/src/common/constants.h
+++ b/src/common/constants.h
@@ -32,6 +32,7 @@
 #define GSETTINGS_KEY_ENABLE_PERSISTENCE "enable-persistence"
 #define GSETTINGS_KEY_SHOW_COUNTDOWN     "show-countdown"
 #define GSETTINGS_KEY_HISTORY_ENABLED    "history-enabled"
+#define GSETTINGS_KEY_FORCE_DISPLAY      "force-display"
 #define NOTIFICATION_BUS_NAME            "org.freedesktop.Notifications"
 #define NOTIFICATION_BUS_PATH            "/org/freedesktop/Notifications"
 

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -1834,8 +1834,10 @@ static gboolean notify_daemon_notify_handler(NotifyDaemonNotifications *object, 
 #endif /* HAVE_X11 */
 	/* fullscreen_window is assumed to be false on Wayland, as there is no trivial way to check */
 
+	gboolean force_display = g_settings_get_boolean (daemon->gsettings, GSETTINGS_KEY_FORCE_DISPLAY);
+
 	/* If on DnD or screensaver, suppress and close notification */
-	if (do_not_disturb || (screensaver_active (GTK_WIDGET (nw)) && urgency != URGENCY_CRITICAL))
+	if (do_not_disturb || (!force_display && screensaver_active (GTK_WIDGET (nw)) && urgency != URGENCY_CRITICAL))
 	{
 		_NotifyPendingClose *notification_data;
 
@@ -1848,12 +1850,12 @@ static gboolean notify_daemon_notify_handler(NotifyDaemonNotifications *object, 
 	}
 	else
 	{
-		/* Show if critical or no fullscreen window */
-		if (urgency == URGENCY_CRITICAL || !fullscreen_window)
+		/* Show if critical, force-display, or no fullscreen window */
+		if (force_display || urgency == URGENCY_CRITICAL || !fullscreen_window)
 			theme_show_notification (nw);
 
-		/* Play sound unless low urgency during fullscreen */
-		if (sound_file != NULL && !(fullscreen_window && urgency == URGENCY_LOW))
+		/* Play sound unless low urgency during fullscreen (when not force-display) */
+		if (sound_file != NULL && (force_display || !(fullscreen_window && urgency == URGENCY_LOW)))
 			sound_play_file (GTK_WIDGET (nw), sound_file);
 	}
 

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -960,7 +960,7 @@ static gboolean _check_expiration(NotifyDaemon* daemon)
 	return has_more_timeouts;
 }
 
-static void _calculate_timeout(NotifyDaemon* daemon, NotifyTimeout* nt, int timeout, gboolean resident)
+static void _calculate_timeout(NotifyDaemon* daemon, NotifyTimeout* nt, int timeout, gboolean resident, guint urgency)
 {
 	GSettings *gsettings = g_settings_new ("org.mate.NotificationDaemon");
 	gboolean persistence_enabled = g_settings_get_boolean (gsettings, "enable-persistence");
@@ -975,7 +975,9 @@ static void _calculate_timeout(NotifyDaemon* daemon, NotifyTimeout* nt, int time
 		g_object_unref (gsettings);
 	}
 
-	if (timeout == 0 || nt->resident)
+	/* Per the spec, critical notifications should not automatically
+	 * expire. They should only be closed by user action. */
+	if (timeout == 0 || nt->resident || urgency == URGENCY_CRITICAL)
 	{
 		nt->has_timeout = FALSE;
 	}
@@ -1046,7 +1048,7 @@ static NotifyTimeout* _store_notification(NotifyDaemon* daemon, GtkWindow* nw,
 	nt->timestamp = g_get_real_time();
 	nt->close_reason = NOTIFYD_CLOSED_EXPIRED; /* Default to expired, since we don't care about active notifications */
 
-	_calculate_timeout(daemon, nt, timeout, resident);
+	_calculate_timeout(daemon, nt, timeout, resident, urgency);
 
 #if GLIB_CHECK_VERSION (2, 68, 0)
 	g_hash_table_insert(daemon->notification_hash, g_memdup2(&id, sizeof(guint)), nt);
@@ -1832,22 +1834,8 @@ static gboolean notify_daemon_notify_handler(NotifyDaemonNotifications *object, 
 #endif /* HAVE_X11 */
 	/* fullscreen_window is assumed to be false on Wayland, as there is no trivial way to check */
 
-	/* If there is no timeout, show the notification also if screensaver
-	 * is active or there are fullscreen windows
-	 */
-	if (!nt->has_timeout || (!screensaver_active (GTK_WIDGET (nw)) && !fullscreen_window))
-	{
-		if (!do_not_disturb)
-		{
-			theme_show_notification (nw);
-
-			if (sound_file != NULL)
-			{
-				sound_play_file (GTK_WIDGET (nw), sound_file);
-			}
-		}
-	}
-	else
+	/* If on DnD or screensaver, suppress and close notification */
+	if (do_not_disturb || (screensaver_active (GTK_WIDGET (nw)) && urgency != URGENCY_CRITICAL))
 	{
 		_NotifyPendingClose *notification_data;
 
@@ -1858,6 +1846,16 @@ static gboolean notify_daemon_notify_handler(NotifyDaemonNotifications *object, 
 		notification_data->daemon = g_object_ref (daemon);
 		g_idle_add ((GSourceFunc) _close_notification_not_shown, notification_data);
 	}
+	else
+	{
+		/* Show if critical or no fullscreen window */
+		if (urgency == URGENCY_CRITICAL || !fullscreen_window)
+			theme_show_notification (nw);
+
+		/* Play sound unless low urgency during fullscreen */
+		if (sound_file != NULL && !(fullscreen_window && urgency == URGENCY_LOW))
+			sound_play_file (GTK_WIDGET (nw), sound_file);
+	}
 
 	g_free (sound_file);
 
@@ -1865,7 +1863,7 @@ static gboolean notify_daemon_notify_handler(NotifyDaemonNotifications *object, 
 
 	if (nt)
 	{
-		_calculate_timeout (daemon, nt, timeout, resident && !transient);
+		_calculate_timeout (daemon, nt, timeout, resident && !transient, urgency);
 	}
 
 	if (resolved_icon) {


### PR DESCRIPTION
Since we have notifications history now, we can make changes to align a bit better with the spec.

- Critical notifications should always be shown and should never automatically expire. They should only be closed by user action.
- Previously, the only notifications that bypassed fullscreen and screensaver suppression were persistent ones. Now, since critical notifications are persistent, we downgrade normal notifications to only play sound on fullscreen.
- Low urgency notifications do not show nor play sound when on fullscreen.
- Do Not Disturb still suppresses all notifications, including critical.

Also added a setting to force display all notifications regardless of fullscreen or whatever (except DnD, since that's an explicit setting from the user).

Fixes #199
Fixes #140