### PR TITLE
daemon: Fix NotificationClosed signal reason for close button

### DIFF
--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -758,8 +758,14 @@ static void _notification_destroyed_cb(GtkWindow* nw, NotifyDaemon* daemon)
 	/*
 	 * This usually won't happen, but can if notification-daemon dies before
 	 * all notifications are closed. Mark them as expired.
+	 *
+	 * But if instead the notification's close button was clicked, the
+	 * "_user_closed" flag will be set on the window, so we send the
+	 * correct reason.
 	 */
-	_close_notification(daemon, NW_GET_NOTIFY_ID(nw), FALSE, NOTIFYD_CLOSED_EXPIRED);
+	gboolean user_closed = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(nw), "_user_closed"));
+	_close_notification(daemon, NW_GET_NOTIFY_ID(nw), FALSE,
+	                    user_closed ? NOTIFYD_CLOSED_USER : NOTIFYD_CLOSED_EXPIRED);
 }
 
 #ifdef HAVE_X11

--- a/src/themes/nodoka/nodoka-theme.c
+++ b/src/themes/nodoka/nodoka-theme.c
@@ -748,6 +748,13 @@ get_theme_info(char **theme_name,
 	*homepage = g_strdup("https://nodoka.fedorahosted.org/");
 }
 
+static void
+close_button_clicked_cb(GtkButton* button, GtkWidget* win)
+{
+	g_object_set_data(G_OBJECT(win), "_user_closed", GINT_TO_POINTER(1));
+	gtk_widget_destroy(win);
+}
+
 /* Create new notification */
 GtkWindow *
 create_notification(UrlClickedCb url_clicked)
@@ -860,8 +867,8 @@ create_notification(UrlClickedCb url_clicked)
 	gtk_button_set_relief(GTK_BUTTON(close_button), GTK_RELIEF_NONE);
 	gtk_container_set_border_width(GTK_CONTAINER(close_button), 0);
 	gtk_widget_set_size_request(close_button, 24, 24);
-	g_signal_connect_swapped(G_OBJECT(close_button), "clicked",
-							 G_CALLBACK(gtk_widget_destroy), win);
+	g_signal_connect(G_OBJECT(close_button), "clicked",
+	                 G_CALLBACK(close_button_clicked_cb), win);
 
 	atkobj = gtk_widget_get_accessible(close_button);
 	atk_action_set_description(ATK_ACTION(atkobj), 0,

--- a/src/themes/slider/theme.c
+++ b/src/themes/slider/theme.c
@@ -306,6 +306,13 @@ static void on_composited_changed(GtkWidget* window, WindowData* windata)
 	gtk_widget_queue_draw (windata->win);
 }
 
+static void
+close_button_clicked_cb(GtkButton* button, GtkWidget* win)
+{
+	g_object_set_data(G_OBJECT(win), "_user_closed", GINT_TO_POINTER(1));
+	gtk_widget_destroy(win);
+}
+
 GtkWindow* create_notification(UrlClickedCb url_clicked)
 {
 	GtkWidget* win;
@@ -400,7 +407,7 @@ GtkWindow* create_notification(UrlClickedCb url_clicked)
 
 	gtk_button_set_relief(GTK_BUTTON(close_button), GTK_RELIEF_NONE);
 	gtk_container_set_border_width(GTK_CONTAINER(close_button), 0);
-	g_signal_connect_swapped(G_OBJECT(close_button), "clicked", G_CALLBACK(gtk_widget_destroy), win);
+	g_signal_connect(G_OBJECT(close_button), "clicked", G_CALLBACK(close_button_clicked_cb), win);
 
 	atkobj = gtk_widget_get_accessible(close_button);
 	atk_action_set_description(ATK_ACTION(atkobj), 0,

--- a/src/themes/standard/theme.c
+++ b/src/themes/standard/theme.c
@@ -642,6 +642,13 @@ static gboolean activate_link(GtkLabel* label, const char* url, WindowData* wind
 	return TRUE;
 }
 
+static void
+close_button_clicked_cb(GtkButton* button, GtkWidget* win)
+{
+	g_object_set_data(G_OBJECT(win), "_user_closed", GINT_TO_POINTER(1));
+	gtk_widget_destroy(win);
+}
+
 GtkWindow* create_notification(UrlClickedCb url_clicked)
 {
 	GtkWidget* spacer;
@@ -754,7 +761,7 @@ GtkWindow* create_notification(UrlClickedCb url_clicked)
 	gtk_button_set_relief(GTK_BUTTON(close_button), GTK_RELIEF_NONE);
 	gtk_container_set_border_width(GTK_CONTAINER(close_button), 0);
 	//gtk_widget_set_size_request(close_button, 20, 20);
-	g_signal_connect_swapped(G_OBJECT(close_button), "clicked", G_CALLBACK(gtk_widget_destroy), win);
+	g_signal_connect(G_OBJECT(close_button), "clicked", G_CALLBACK(close_button_clicked_cb), win);
 
 	atkobj = gtk_widget_get_accessible(close_button);
 	atk_action_set_description(ATK_ACTION(atkobj), 0,


### PR DESCRIPTION
When clicking the close button on a notification, the D-Bus signal incorrectly sent reason=1 (expired) instead of reason=2 (dismissed).

Fixed by setting a flag on the notification window in the close button callback before destroying it, and checking this flag in the callback to send the correct close reason.

Fixes #129